### PR TITLE
chore(web): standardize playwright screenshot capture flow

### DIFF
--- a/.agents/skills/push-pr/SKILL.md
+++ b/.agents/skills/push-pr/SKILL.md
@@ -90,15 +90,19 @@ gh pr view --json number,title,body,url,headRefName,baseRefName
 
 ```markdown
 ## Description
+
 <what changed>
 
 ## Validation
+
 - <test or check>
 
 ## Risks
+
 - <known risk or `None`>
 
 ## Visuals
+
 - <GitHub attachment URL or `N/A`>
 ```
 
@@ -129,23 +133,19 @@ gh pr edit <number> --title "<new-title>" --body-file <temp-body-file>
 
 If changes are visually verifiable (UI/layout/styling/interaction):
 
-1. Resolve the correct local dev server for this change:
-   - Prefer a server started in the current session for the current worktree/branch.
-   - If multiple local dev servers exist, choose the one associated with the files changed in this task.
-   - If no suitable server is running, start the relevant local dev server from this worktree and use its reported `Local` URL.
-   - If server ownership is ambiguous, start a fresh server in the current worktree and use that URL for screenshots.
-2. Invoke `$playwright` against that selected local URL to capture at least one representative screenshot.
-3. Save screenshot(s) outside the repo, for example in a temp directory:
+1. Use the page specs in `apps/web/src/pages/*.spec.ts` for screenshots.
+2. Each page spec should include `maybeCaptureScreenshot(page)` that:
+   - Returns immediately unless `process.env.PLAYWRIGHT_SCREENSHOT` is set.
+   - Writes to `<repoRoot>/output/<page>.png` (`landing-page.png`, `report-page.png`, `fight-page.png`).
+3. Ensure each page spec uses appropriate mocks so the captured page is a valid state for PR context.
+4. Run the specific page spec with screenshots enabled, for example:
 
 ```bash
-tmp_dir="$(mktemp -d)"
-# store screenshots under "$tmp_dir"
+PLAYWRIGHT_SCREENSHOT=1 pnpm --filter @wow-threat/web exec playwright test src/pages/landing-page.spec.ts
 ```
 
-4. Never add screenshot files to git or commit them to the branch.
-5. Upload screenshot(s) to GitHub as PR attachments (for example by editing the PR description in GitHub and attaching the local temp files so GitHub returns `github.com/user-attachments/...` URLs).
-6. Insert those GitHub attachment links in the PR body `## Visuals` section.
-7. Remove local temp screenshots after the PR body is updated.
+5. Use the generated `<repoRoot>/output/<page>.png` image in the PR `## Visuals` section (upload as a GitHub attachment and include the resulting URL).
+6. Leave screenshot files in `output/`; this path is gitignored and images are expected to be overwritten on future runs.
 
 Preferred markdown format:
 
@@ -164,4 +164,4 @@ After running this skill, leave the repository in this state:
 3. Branch is pushed to origin.
 4. PR exists and points to the current branch state.
 5. PR title/body are up to date with branch intent.
-6. Visual proof is attached in PR description when applicable, without committing image files to the repository.
+6. Visual proof is attached in PR description when applicable, sourced from `<repoRoot>/output/<page>.png` screenshots without committing image files.

--- a/apps/web/src/pages/fight-page.spec.ts
+++ b/apps/web/src/pages/fight-page.spec.ts
@@ -2,7 +2,9 @@
  * Playwright coverage for fight page chart and interaction flows.
  */
 import { type Page, expect, test } from '@playwright/test'
+import { mkdir } from 'node:fs/promises'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import {
   e2eReportId,
@@ -11,20 +13,18 @@ import {
 import { FightPageObject } from '../test/page-objects/fight-page'
 
 const svgFightUrl = `/report/${e2eReportId}/fight/26?renderer=svg`
+const repoRoot = path.resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../../..',
+)
+const screenshotPath = path.join(repoRoot, 'output', 'fight-page.png')
 
-async function maybeCaptureFightScreenshot({
-  page,
-  screenshotName,
-}: {
-  page: Page
-  screenshotName: string
-}): Promise<void> {
-  const screenshotDir = process.env.PLAYWRIGHT_SCREENSHOT_DIR
-  if (!screenshotDir) {
+async function maybeCaptureScreenshot(page: Page): Promise<void> {
+  if (!process.env.PLAYWRIGHT_SCREENSHOT) {
     return
   }
 
-  const screenshotPath = path.join(screenshotDir, `${screenshotName}.png`)
+  await mkdir(path.dirname(screenshotPath), { recursive: true })
   await page.screenshot({
     path: screenshotPath,
     fullPage: true,
@@ -79,10 +79,7 @@ test.describe('fight page', () => {
     await expect(fightPage.chart.legendFocus('Aegistank')).toBeVisible()
     await expect(page.getByText('Fixate/Taunt')).toBeVisible()
     await expect(fightPage.chart.legendToggle('Wolfie')).toHaveCount(0)
-    await maybeCaptureFightScreenshot({
-      page,
-      screenshotName: 'fight-page-fixate-bands',
-    })
+    await maybeCaptureScreenshot(page)
 
     await expect(fightPage.chart.showEnergizeEventsCheckbox()).not.toBeChecked()
     await expect(fightPage.chart.showFixateBandsCheckbox()).toBeChecked()

--- a/apps/web/src/pages/landing-page.spec.ts
+++ b/apps/web/src/pages/landing-page.spec.ts
@@ -2,6 +2,9 @@
  * Playwright coverage for landing page critical flows.
  */
 import { type Page, expect, test } from '@playwright/test'
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import {
   e2eReportId,
@@ -12,10 +15,28 @@ import {
 import { KeyboardShortcutsOverlayObject } from '../test/page-objects/components/keyboard-shortcuts-overlay-object'
 import { RecentReportsObject } from '../test/page-objects/landing-page/recent-reports-object'
 
+const repoRoot = path.resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../../..',
+)
+const screenshotPath = path.join(repoRoot, 'output', 'landing-page.png')
+
 async function fillReportInput(page: Page, value: string): Promise<void> {
   const reportInput = page.getByRole('combobox', { name: 'Open report' })
   await reportInput.click()
   await reportInput.fill(value)
+}
+
+async function maybeCaptureScreenshot(page: Page): Promise<void> {
+  if (!process.env.PLAYWRIGHT_SCREENSHOT) {
+    return
+  }
+
+  await mkdir(path.dirname(screenshotPath), { recursive: true })
+  await page.screenshot({
+    path: screenshotPath,
+    fullPage: true,
+  })
 }
 
 test.describe('landing page', () => {
@@ -81,6 +102,7 @@ test.describe('landing page', () => {
     await expect(page.getByText(/Ctrl|⌘/)).toBeVisible()
     await expect(recentReports.exampleReportsSection()).toBeVisible()
     await expect(recentReports.exampleReportsList()).toBeVisible()
+    await maybeCaptureScreenshot(page)
     await recentReports.exampleReportLink('Fresh Example').click()
 
     await expect(page).toHaveURL(new RegExp(`/report/${e2eReportId}`))

--- a/apps/web/src/pages/report-page.spec.ts
+++ b/apps/web/src/pages/report-page.spec.ts
@@ -1,13 +1,34 @@
 /**
  * Playwright coverage for report page critical flows.
  */
-import { expect, test } from '@playwright/test'
+import { type Page, expect, test } from '@playwright/test'
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import {
   e2eReportId,
   setupThreatApiMocks,
 } from '../test/helpers/e2e-threat-mocks'
 import { FightQuickSwitcherObject } from '../test/page-objects/components/fight-quick-switcher-object'
+
+const repoRoot = path.resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../../..',
+)
+const screenshotPath = path.join(repoRoot, 'output', 'report-page.png')
+
+async function maybeCaptureScreenshot(page: Page): Promise<void> {
+  if (!process.env.PLAYWRIGHT_SCREENSHOT) {
+    return
+  }
+
+  await mkdir(path.dirname(screenshotPath), { recursive: true })
+  await page.screenshot({
+    path: screenshotPath,
+    fullPage: true,
+  })
+}
 
 test.describe('report page', () => {
   test.beforeEach(async ({ page }) => {
@@ -27,6 +48,7 @@ test.describe('report page', () => {
         'Choose a fight from the quick switcher to view the chart and legend.',
       ),
     ).toBeVisible()
+    await maybeCaptureScreenshot(page)
   })
 
   test('shows only boss kills in quick switch order', async ({ page }) => {


### PR DESCRIPTION
## Description

- update each page Playwright spec to support `maybeCaptureScreenshot(page)` gated by `process.env.PLAYWRIGHT_SCREENSHOT`
- write deterministic screenshots to `<repoRoot>/output/<page>.png` for landing, report, and fight pages
- update `$push-pr` skill instructions to document this screenshot workflow and PR visuals usage

## Validation

- `pnpm --filter @wow-threat/web lint`
- `pnpm --filter @wow-threat/web typecheck`
- `pnpm --filter @wow-threat/web test`
- `PLAYWRIGHT_SCREENSHOT=1 pnpm --filter @wow-threat/web exec playwright test src/pages/landing-page.spec.ts src/pages/report-page.spec.ts src/pages/fight-page.spec.ts`
- `PLAYWRIGHT_SCREENSHOT=1 pnpm --filter @wow-threat/web exec playwright test src/pages/report-page.spec.ts`

## Risks

- low: screenshot hooks are env-gated and only affect test runs when `PLAYWRIGHT_SCREENSHOT` is set

## Visuals

![Report page screenshot](https://files.catbox.moe/fv4e2p.png)
