### PR TITLE
chore(deps): only do dependabot at the root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,38 +4,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-
-  - package-ecosystem: npm
-    directory: /apps/api
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: npm
-    directory: /apps/web
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: npm
-    directory: /packages/config
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: npm
-    directory: /packages/engine
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: npm
-    directory: /packages/shared
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: npm
-    directory: /packages/wcl-types
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: npm
-    directory: /tooling/typescript-config
-    schedule:
-      interval: weekly


### PR DESCRIPTION
## Description

Restricts Dependabot updates to the repository root by removing per-workspace update blocks from `.github/dependabot.yml`.

## Validation

- Not run (GitHub configuration-only change)

## Risks

- Dependabot will no longer open package update PRs scoped to removed directories unless root configuration already covers them.

## Visuals

- N/A
