### PR TITLE
fix(web): stabilize isolate-focused-player hotkey

### DIFF
--- a/apps/web/src/components/threat-chart.tsx
+++ b/apps/web/src/components/threat-chart.tsx
@@ -76,6 +76,7 @@ export const ThreatChart: FC<ThreatChartProps> = ({
   onRegisterResetZoom,
 }) => {
   const chartRef = useRef<ReactEChartsCore>(null)
+  const focusedActorIdRef = useRef<number | null>(focusedActorId)
   const [isChartReady, setIsChartReady] = useState(false)
   const themeColors = useThreatChartThemeColors()
   const {
@@ -116,6 +117,10 @@ export const ThreatChart: FC<ThreatChartProps> = ({
     onVisiblePlayerIdsChange,
     series,
   })
+  const resolveFocusedActorId = useCallback(
+    (): number | null => focusedActorIdRef.current,
+    [],
+  )
   const {
     filteredPlayerSearchOptions,
     handlePlayerSearchInputKeyDown,
@@ -131,6 +136,7 @@ export const ThreatChart: FC<ThreatChartProps> = ({
   } = useThreatChartPlayerSearch({
     clearIsolate,
     focusedActorId,
+    resolveFocusedActorId,
     onFocusAndAddPlayer,
     onFocusAndIsolatePlayer,
     series,
@@ -145,6 +151,18 @@ export const ThreatChart: FC<ThreatChartProps> = ({
 
     onVisiblePlayerIdsChange?.(allPlayerIds)
   }, [allPlayerIds, clearIsolate, onClearSelections, onVisiblePlayerIdsChange])
+
+  useEffect(() => {
+    focusedActorIdRef.current = focusedActorId
+  }, [focusedActorId])
+
+  const handleActorFocus = useCallback(
+    (actorId: number): void => {
+      focusedActorIdRef.current = actorId
+      onSeriesClick(actorId)
+    },
+    [onSeriesClick],
+  )
 
   useEffect(() => {
     onChartReadyChange?.(isChartReady)
@@ -244,7 +262,7 @@ export const ThreatChart: FC<ThreatChartProps> = ({
   const handleSeriesChartClick = useThreatChartSeriesClickHandler({
     actorIdByLabel,
     consumeSuppressedSeriesClick,
-    onSeriesClick,
+    onSeriesClick: handleActorFocus,
   })
 
   const tooltipFormatter = createThreatChartTooltipFormatter({
@@ -421,7 +439,7 @@ export const ThreatChart: FC<ThreatChartProps> = ({
           series={series}
           isActorVisible={isActorVisible}
           onActorClick={handleLegendItemClick}
-          onActorFocus={onSeriesClick}
+          onActorFocus={handleActorFocus}
           pinnedPlayerIds={pinnedPlayerIds}
           onTogglePinnedPlayer={onTogglePinnedPlayer}
           showClearSelections={canClearIsolate}

--- a/apps/web/src/hooks/use-threat-chart-player-search.test.ts
+++ b/apps/web/src/hooks/use-threat-chart-player-search.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for threat-chart player search state and selection behavior.
+ */
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ThreatSeries } from '../types/app'
+import { useThreatChartPlayerSearch } from './use-threat-chart-player-search'
+
+function createSeries(
+  overrides: Partial<ThreatSeries> &
+    Pick<ThreatSeries, 'actorId' | 'actorType' | 'label'>,
+): ThreatSeries {
+  return {
+    actorId: overrides.actorId,
+    actorName: overrides.label,
+    actorClass: null,
+    actorType: overrides.actorType,
+    ownerId: null,
+    label: overrides.label,
+    color: '#c79c6e',
+    points: [],
+    maxThreat: 0,
+    totalThreat: 0,
+    totalDamage: 0,
+    totalHealing: 0,
+    stateVisualSegments: [],
+    fixateWindows: [],
+    invulnerabilityWindows: [],
+    ...overrides,
+  }
+}
+
+describe('useThreatChartPlayerSearch', () => {
+  it('isolates the latest focused actor resolved by callback', () => {
+    const onFocusAndAddPlayer = vi.fn()
+    const onFocusAndIsolatePlayer = vi.fn()
+    const clearIsolate = vi.fn()
+    let resolvedFocusedActorId: number | null = null
+    const series = [
+      createSeries({
+        actorId: 1,
+        actorType: 'Player',
+        label: 'Aegistank',
+      }),
+      createSeries({
+        actorId: 2,
+        actorType: 'Player',
+        label: 'Bladefury',
+      }),
+    ]
+
+    const { result } = renderHook(() =>
+      useThreatChartPlayerSearch({
+        clearIsolate,
+        focusedActorId: null,
+        onFocusAndAddPlayer,
+        onFocusAndIsolatePlayer,
+        resolveFocusedActorId: () => resolvedFocusedActorId,
+        series,
+      }),
+    )
+
+    resolvedFocusedActorId = 2
+
+    act(() => {
+      result.current.isolateFocusedPlayer()
+    })
+
+    expect(onFocusAndIsolatePlayer).toHaveBeenCalledWith(2)
+    expect(onFocusAndAddPlayer).not.toHaveBeenCalled()
+    expect(clearIsolate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/hooks/use-threat-chart-player-search.ts
+++ b/apps/web/src/hooks/use-threat-chart-player-search.ts
@@ -64,12 +64,14 @@ export interface UseThreatChartPlayerSearchResult {
 export function useThreatChartPlayerSearch({
   series,
   focusedActorId,
+  resolveFocusedActorId,
   onFocusAndAddPlayer,
   onFocusAndIsolatePlayer,
   clearIsolate,
 }: {
   series: ThreatSeries[]
   focusedActorId: number | null
+  resolveFocusedActorId?: () => number | null
   onFocusAndAddPlayer: (playerId: number) => void
   onFocusAndIsolatePlayer: (playerId: number) => void
   clearIsolate: () => void
@@ -79,14 +81,9 @@ export function useThreatChartPlayerSearch({
   const [highlightedPlayerId, setHighlightedPlayerId] = useState<number | null>(
     null,
   )
-
-  const focusedPlayerId = useMemo(
-    () =>
-      resolveFocusedPlayerId({
-        focusedActorId,
-        series,
-      }),
-    [focusedActorId, series],
+  const resolveCurrentFocusedActorId = useCallback(
+    (): number | null => resolveFocusedActorId?.() ?? focusedActorId,
+    [focusedActorId, resolveFocusedActorId],
   )
 
   const playerSearchOptions = useMemo(
@@ -210,6 +207,10 @@ export function useThreatChartPlayerSearch({
   )
 
   const isolateFocusedPlayer = useCallback((): void => {
+    const focusedPlayerId = resolveFocusedPlayerId({
+      focusedActorId: resolveCurrentFocusedActorId(),
+      series,
+    })
     if (focusedPlayerId === null) {
       return
     }
@@ -218,7 +219,7 @@ export function useThreatChartPlayerSearch({
       playerId: focusedPlayerId,
       shouldAddToFilter: false,
     })
-  }, [focusedPlayerId, selectPlayer])
+  }, [resolveCurrentFocusedActorId, selectPlayer, series])
 
   return {
     isPlayerSearchOpen,


### PR DESCRIPTION
## Description

- fix stale focused-player reads in fight chart keyboard shortcuts after dependency upgrades
- keep a live focused actor ref in `ThreatChart` and use it for both legend/chart focus interactions and isolate-shortcut resolution
- extend `useThreatChartPlayerSearch` with an optional focus resolver callback and add a targeted unit test for this timing path

## Validation

- `pnpm --filter @wow-threat/web lint`
- `pnpm --filter @wow-threat/web typecheck`
- `pnpm --filter @wow-threat/web test`
- `pnpm --filter @wow-threat/web exec vitest run src/hooks/use-threat-chart-player-search.test.ts`
- `pnpm --filter @wow-threat/web exec playwright test src/pages/fight-page.spec.ts -g "supports keyboard shortcuts for toggles, clear isolate, and shortcuts overlay"`
- `pnpm --filter @wow-threat/web e2e`
- `PLAYWRIGHT_SCREENSHOT=1 pnpm --filter @wow-threat/web exec playwright test src/pages/fight-page.spec.ts -g "defaults to the main boss and shows expected players in the legend"`

## Risks

- low: focus handling now uses a ref fallback; behavior is covered by unit + e2e tests but still depends on current focus event wiring

## Visuals

![Updated fight page keyboard interaction state](https://github.com/user-attachments/assets/5739a9ec-e2bd-4165-8519-786246d794ab)
