### PR TITLE
chore(todo): finalize web discovery tasks as ready

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,15 +37,15 @@
 
 | ID      | Package              | Status      | Priority | Size | Title                                                     |
 | ------- | -------------------- | ----------- | -------- | ---- | --------------------------------------------------------- |
-| WEB-012 | `@wow-threat/web`    | DISCOVERY   | P2       | M    | Add Starred, Guild lists at top                           |
+| WEB-012 | `@wow-threat/web`    | READY       | P2       | M    | Add Starred, Guild lists at top                           |
 | WEB-015 | `@wow-threat/web`    | READY       | P2       | S    | Isolate key toggles between isolated and previous players |
 | WEB-016 | `@wow-threat/web`    | READY       | P2       | S    | Zoom key toggles between no zoom and previous zoom        |
-| WEB-017 | `@wow-threat/web`    | DISCOVERY   | P2       | M    | Fuzzy target selector                                     |
-| WEB-018 | `@wow-threat/web`    | DISCOVERY   | P2       | M    | Fuzzy fight selector                                      |
-| WEB-019 | `@wow-threat/web`    | DISCOVERY   | P0       | M    | Fight event pagination currently blocks the UI thread     |
+| WEB-017 | `@wow-threat/web`    | READY       | P2       | M    | Fuzzy target selector                                     |
+| WEB-018 | `@wow-threat/web`    | READY       | P2       | M    | Fuzzy fight selector                                      |
+| WEB-019 | `@wow-threat/web`    | READY       | P0       | M    | Fight event pagination currently blocks the UI thread     |
 | WEB-021 | `@wow-threat/web`    | READY       | P2       | S    | Keyboard shortcut for filter to tanks only                |
 | WEB-027 | `@wow-threat/web`    | READY       | P3       | XS   | Make toggled players in legend more prominent             |
-| WEB-032 | `@wow-threat/web`    | DISCOVERY   | P0       | L    | Batch + stream events to worker/IndexedDB to prevent jank |
+| WEB-032 | `@wow-threat/web`    | READY       | P0       | L    | Batch + stream events to worker/IndexedDB to prevent jank |
 
 ## Historical Completed IDs
 
@@ -90,7 +90,7 @@
 id: WEB-012
 title: Add starred and guild lists at top
 package: @wow-threat/web
-status: DISCOVERY
+status: READY
 priority: P2
 size: M
 depends_on: []
@@ -100,9 +100,13 @@ files_hint:
   - apps/web/src/hooks/use-user-recent-reports.ts
   - apps/web/src/components
 acceptance_criteria:
-  - Define canonical placement and ordering rules for starred and guild lists.
-  - Define persistence and source-of-truth behavior for starred and guild membership.
-  - Capture final UX spec in this card, then promote status to READY.
+  - Add centered header quick-access text dropdown triggers for Starred and Guild in the main app header on all routes.
+  - Use dropdown-menu behavior (not Select) and navigate immediately when an item is selected.
+  - Starred dropdown shows up to 10 starred reports sorted by report startTime desc, with fallback to starredAt desc when startTime is missing.
+  - Guild dropdown shows up to 10 reports from starred guild feeds sorted by report startTime desc.
+  - Empty dropdown states show helper copy instead of hidden menus (for example, "Star reports to see them here.").
+  - Existing landing-page Recent logs and Guild logs sections remain and align to the same ordering rules.
+  - Source of truth remains user settings starredReports/starredEntities plus starred guild report query data.
 validation:
   - pnpm --filter @wow-threat/web lint
   - pnpm --filter @wow-threat/web typecheck
@@ -183,7 +187,7 @@ commit_sha: null
 id: WEB-017
 title: Fuzzy target selector
 package: @wow-threat/web
-status: DISCOVERY
+status: READY
 priority: P2
 size: M
 depends_on: []
@@ -192,10 +196,12 @@ files_hint:
   - apps/web/src/lib/fight-navigation.ts
   - apps/web/src/pages/fight-page.tsx
 acceptance_criteria:
-  - Define trigger key behavior for t and conflict handling with existing shortcuts.
-  - Define candidate ranking and display fields for fuzzy target matches.
-  - Define behavior when selected target has no events in current window.
-  - Capture final UX spec in this card, then promote status to READY.
+  - Pressing t opens a fuzzy target selector on fight page when focus is not in an input/control context.
+  - Candidate set includes boss and non-boss targets, with bosses ranked ahead of non-boss candidates.
+  - Ranking priority is exact match, then prefix match, then fuzzy match.
+  - Target result rows show target name, boss badge (when applicable), actor ID, and instance ID.
+  - Selecting a target updates targetId in the URL immediately and closes the picker.
+  - If a selected target has no events in the current window, keep existing behavior (no automatic window reset/change).
 validation:
   - pnpm --filter @wow-threat/web lint
   - pnpm --filter @wow-threat/web typecheck
@@ -213,7 +219,7 @@ commit_sha: null
 id: WEB-018
 title: Fuzzy fight selector
 package: @wow-threat/web
-status: DISCOVERY
+status: READY
 priority: P2
 size: M
 depends_on: []
@@ -222,10 +228,13 @@ files_hint:
   - apps/web/src/lib/fight-navigation.ts
   - apps/web/src/pages/report-page.spec.ts
 acceptance_criteria:
-  - Define trigger key behavior and interaction with existing quick-open flows.
-  - Define fuzzy ranking fields for fights (boss, encounter id, duration, timestamp).
-  - Define post-selection behavior for preserving selected players/target/window params.
-  - Capture final UX spec in this card, then promote status to READY.
+  - Pressing f opens a fuzzy fight selector on report and fight pages where quick-switch navigation is available, when not focused in input/control context.
+  - Fuzzy selector coexists with the existing quick-switch UI.
+  - Candidate set includes all fights (boss kills, boss wipes, and trash fights).
+  - Fight results display kill/wipe status, with wipes visually de-emphasized.
+  - Ranking priority is exact match, then prefix match, then fuzzy match by fight/boss name.
+  - Selecting a fight navigates immediately and closes the picker.
+  - Selection behavior matches quick-switch links: preserve pinned-player behavior and reset other transient query params.
 validation:
   - pnpm --filter @wow-threat/web lint
   - pnpm --filter @wow-threat/web typecheck
@@ -243,7 +252,7 @@ commit_sha: null
 id: WEB-019
 title: Fight event pagination retrieves all pages while blocking UI thread
 package: @wow-threat/web
-status: DISCOVERY
+status: READY
 priority: P0
 size: M
 depends_on: []
@@ -253,10 +262,11 @@ files_hint:
   - apps/web/src/lib/client-threat-engine.ts
   - apps/web/src/pages/fight-page.spec.ts
 acceptance_criteria:
-  - Define measurable performance target for main-thread responsiveness.
-  - Define whether pagination fetches are incremental, parallel, or adaptive by page count.
-  - Define UX loading states while pages stream in.
-  - Capture final implementation spec in this card, then promote status to READY.
+  - Keep fight-event pagination sequential and cursor-driven (no parallel page fetching).
+  - Yield to the event loop after every page fetch iteration (for example setTimeout(0) or equivalent) so UI rendering/input is not starved.
+  - On context change/newer request, stop fetching subsequent pages and discard stale partial results.
+  - If a page fetch fails, fail fast with existing error handling and no automatic retries.
+  - Preserve page ordering and ensure successful loads still render fight page/chart end-to-end.
 validation:
   - pnpm --filter @wow-threat/web lint
   - pnpm --filter @wow-threat/web typecheck
@@ -335,7 +345,7 @@ commit_sha: null
 id: WEB-032
 title: Batch and stream events to or from web worker and IndexedDB to prevent long frames
 package: @wow-threat/web
-status: DISCOVERY
+status: READY
 priority: P0
 size: L
 depends_on:
@@ -346,10 +356,13 @@ files_hint:
   - apps/web/src/workers/threat-engine-worker-types.ts
   - apps/web/src/lib/client-threat-engine.ts
 acceptance_criteria:
-  - Define target frame-time budget and throughput goals for large fights.
-  - Define message protocol for batched worker transport.
-  - Define IndexedDB write and read batching strategy with cancellation behavior.
-  - Capture final implementation spec in this card, then promote status to READY.
+  - Keep page fetches sequential, then chunk raw events into configurable chunk size (default 10000) before persistence/transfer.
+  - Persist raw chunks in IndexedDB under a per-request job key (reportId/fightId/requestId) and start worker processing only after all chunks are written.
+  - Worker reads raw chunks from IndexedDB, processes events, writes augmented cache output, and returns completion status to main thread.
+  - Raw chunk records are cleaned up after processing on both success and failure paths.
+  - Cancellation/stale-context behavior matches WEB-019: discard stale partials/results and stop additional work.
+  - If IndexedDB is unavailable or errors, fallback to current in-memory worker payload flow.
+  - Performance target is no obvious long-frame stalls (about 300ms) on large fights (around 40k-60k events), with acceptable tradeoff that small fights stay fast and large-fight load time does not regress dramatically.
 validation:
   - pnpm --filter @wow-threat/web lint
   - pnpm --filter @wow-threat/web typecheck


### PR DESCRIPTION
## Description

Refined discovery requirements in `TODO.md` and promoted five web backlog cards to `READY`:

- WEB-012
- WEB-017
- WEB-018
- WEB-019
- WEB-032

Each card now contains concrete acceptance criteria for behavior, ordering, cancellation/error handling, and performance expectations so implementation can proceed without additional discovery.

## Validation

- Not run (documentation/backlog update only)

## Risks

- None

## Visuals

- N/A
