### PR TITLE
fix(web): preserve linked session during auth rehydration

### DIFF
--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { requestJson } from './client'
 
 const getFirebaseAuthMock = vi.fn()
+const onAuthStateChangedMock = vi.fn()
 const signInAnonymouslyMock = vi.fn()
 
 vi.mock('../lib/firebase', () => ({
@@ -13,13 +14,24 @@ vi.mock('../lib/firebase', () => ({
 }))
 
 vi.mock('firebase/auth', () => ({
+  onAuthStateChanged: (...args: unknown[]) => onAuthStateChangedMock(...args),
   signInAnonymously: (...args: unknown[]) => signInAnonymouslyMock(...args),
 }))
 
 describe('requestJson', () => {
   beforeEach(() => {
     getFirebaseAuthMock.mockReset()
+    onAuthStateChangedMock.mockReset()
     signInAnonymouslyMock.mockReset()
+    onAuthStateChangedMock.mockImplementation(
+      (
+        auth: { currentUser: unknown },
+        callback: (user: unknown) => void,
+      ): (() => void) => {
+        callback(auth.currentUser)
+        return vi.fn()
+      },
+    )
     vi.unstubAllGlobals()
   })
 
@@ -91,6 +103,54 @@ describe('requestJson', () => {
     const requestHeaders = new Headers(requestInit?.headers)
     expect(requestHeaders.get('Authorization')).toBe(
       'Bearer anonymous-id-token',
+    )
+  })
+
+  it('waits for auth rehydration before anonymous fallback', async () => {
+    const persistedGetIdToken = vi.fn(async () => 'persisted-id-token')
+    const auth: {
+      currentUser: {
+        getIdToken: () => Promise<string>
+      } | null
+    } = {
+      currentUser: null,
+    }
+    getFirebaseAuthMock.mockReturnValue(auth)
+    onAuthStateChangedMock.mockImplementation(
+      (
+        _auth: typeof auth,
+        callback: (user: typeof auth.currentUser) => void,
+      ): (() => void) => {
+        auth.currentUser = {
+          getIdToken: persistedGetIdToken,
+        }
+        callback(auth.currentUser)
+        return vi.fn()
+      },
+    )
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await requestJson<{ ok: boolean }>(
+      'http://localhost:8788/v1/reports/ABC123',
+    )
+
+    expect(response.ok).toBe(true)
+    expect(signInAnonymouslyMock).not.toHaveBeenCalled()
+    expect(persistedGetIdToken).toHaveBeenCalledTimes(1)
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
+    const requestHeaders = new Headers(requestInit?.headers)
+    expect(requestHeaders.get('Authorization')).toBe(
+      'Bearer persisted-id-token',
     )
   })
 })

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,7 +1,7 @@
 /**
  * Minimal fetch client for API requests.
  */
-import { type Auth, signInAnonymously } from 'firebase/auth'
+import { type Auth, onAuthStateChanged, signInAnonymously } from 'firebase/auth'
 
 import { getFirebaseAuth } from '../lib/firebase'
 
@@ -15,8 +15,46 @@ export class ApiClientError extends Error {
 }
 
 let inFlightAnonymousSignIn: Promise<string | null> | null = null
+const authStateReadyByInstance = new WeakMap<Auth, Promise<void>>()
+
+function waitForInitialAuthState(auth: Auth): Promise<void> {
+  if (auth.currentUser) {
+    return Promise.resolve()
+  }
+
+  const existingPromise = authStateReadyByInstance.get(auth)
+  if (existingPromise) {
+    return existingPromise
+  }
+
+  const authStateReadyPromise = new Promise<void>((resolve) => {
+    let hasResolved = false
+    let unsubscribe: (() => void) | null = null
+    const resolveOnce = (): void => {
+      if (hasResolved) {
+        return
+      }
+
+      hasResolved = true
+      unsubscribe?.()
+      resolve()
+    }
+
+    unsubscribe = onAuthStateChanged(auth, resolveOnce, resolveOnce)
+  }).finally(() => {
+    authStateReadyByInstance.delete(auth)
+  })
+
+  authStateReadyByInstance.set(auth, authStateReadyPromise)
+  return authStateReadyPromise
+}
 
 async function getFirebaseIdToken(auth: Auth): Promise<string | null> {
+  if (auth.currentUser) {
+    return auth.currentUser.getIdToken()
+  }
+
+  await waitForInitialAuthState(auth)
   if (auth.currentUser) {
     return auth.currentUser.getIdToken()
   }


### PR DESCRIPTION
## Description

Fix a Firebase auth rehydration race in the web API client that could replace a persisted WCL-linked session with a new anonymous session.

`requestJson` now waits for the initial `onAuthStateChanged` resolution before attempting anonymous sign-in. If a persisted user session rehydrates, that token is used; anonymous fallback only happens when no user is resolved.

Added regression tests to cover both anonymous fallback behavior and the persisted-session rehydration path.

## Validation

- `pnpm --filter @wow-threat/web exec vitest run src/api/client.test.ts`
- `pnpm --filter @wow-threat/web lint`
- `pnpm --filter @wow-threat/web typecheck`
- `pnpm --filter @wow-threat/web test`
- `pnpm --filter @wow-threat/web exec playwright test src/pages/landing-page.spec.ts`

## Risks

- Low: first API call may wait briefly for initial Firebase auth-state hydration before falling back.

## Visuals

- N/A
