### PR TITLE
Add fuzzy target search overlay, ranking, and 'T' hotkey with tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -40,7 +40,6 @@
 | WEB-012 | `@wow-threat/web`    | READY       | P2       | M    | Add Starred, Guild lists at top                           |
 | WEB-015 | `@wow-threat/web`    | READY       | P2       | S    | Isolate key toggles between isolated and previous players |
 | WEB-016 | `@wow-threat/web`    | READY       | P2       | S    | Zoom key toggles between no zoom and previous zoom        |
-| WEB-017 | `@wow-threat/web`    | READY       | P2       | M    | Fuzzy target selector                                     |
 | WEB-018 | `@wow-threat/web`    | READY       | P2       | M    | Fuzzy fight selector                                      |
 | WEB-019 | `@wow-threat/web`    | READY       | P0       | M    | Fight event pagination currently blocks the UI thread     |
 | WEB-021 | `@wow-threat/web`    | READY       | P2       | S    | Keyboard shortcut for filter to tanks only                |
@@ -176,38 +175,6 @@ validation:
   - pnpm --filter @wow-threat/web exec playwright test src/pages/fight-page.spec.ts
 branch_name: codex/web-016-zoom-key-toggle
 worktree_path: ../wow-threat-web-016
-publish: auto_push_pr
-pr_url: null
-commit_sha: null
-```
-
-### WEB-017 - Fuzzy target selector
-
-```yaml
-id: WEB-017
-title: Fuzzy target selector
-package: @wow-threat/web
-status: READY
-priority: P2
-size: M
-depends_on: []
-files_hint:
-  - apps/web/src/components/threat-chart-controls.tsx
-  - apps/web/src/lib/fight-navigation.ts
-  - apps/web/src/pages/fight-page.tsx
-acceptance_criteria:
-  - Pressing t opens a fuzzy target selector on fight page when focus is not in an input/control context.
-  - Candidate set includes boss and non-boss targets, with bosses ranked ahead of non-boss candidates.
-  - Ranking priority is exact match, then prefix match, then fuzzy match.
-  - Target result rows show target name, boss badge (when applicable), actor ID, and instance ID.
-  - Selecting a target updates targetId in the URL immediately and closes the picker.
-  - If a selected target has no events in the current window, keep existing behavior (no automatic window reset/change).
-validation:
-  - pnpm --filter @wow-threat/web lint
-  - pnpm --filter @wow-threat/web typecheck
-  - pnpm --filter @wow-threat/web test
-branch_name: codex/web-017-fuzzy-target-selector
-worktree_path: ../wow-threat-web-017
 publish: auto_push_pr
 pr_url: null
 commit_sha: null

--- a/apps/web/src/components/fight-target-search.tsx
+++ b/apps/web/src/components/fight-target-search.tsx
@@ -1,0 +1,115 @@
+/**
+ * Target search overlay used by fight-page keyboard shortcuts.
+ */
+import type { KeyboardEventHandler } from 'react'
+
+import type { TargetSearchOption } from '../lib/target-search'
+import { Input } from './ui/input'
+import { Kbd } from './ui/kbd'
+
+export interface FightTargetSearchProps {
+  isOpen: boolean
+  query: string
+  options: TargetSearchOption[]
+  highlightedTargetKey: string | null
+  onClose: () => void
+  onQueryChange: (query: string) => void
+  onInputKeyDown: KeyboardEventHandler<HTMLInputElement>
+  onHighlightTarget: (targetKey: string) => void
+  onSelectTarget: (targetKey: string) => void
+}
+
+/** Render keyboard target search overlay and option list interactions. */
+export function FightTargetSearch({
+  isOpen,
+  query,
+  options,
+  highlightedTargetKey,
+  onClose,
+  onQueryChange,
+  onInputKeyDown,
+  onHighlightTarget,
+  onSelectTarget,
+}: FightTargetSearchProps) {
+  if (!isOpen) {
+    return null
+  }
+
+  return (
+    <div
+      aria-label="Target search"
+      aria-modal="false"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 p-4"
+      role="dialog"
+      onClick={() => {
+        onClose()
+      }}
+    >
+      <div
+        className="w-full max-w-lg rounded-lg border border-border bg-card p-3 shadow-lg"
+        onClick={(event) => {
+          event.stopPropagation()
+        }}
+      >
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold">Target search</h2>
+          <Kbd>T</Kbd>
+        </div>
+        <Input
+          autoFocus
+          aria-label="Search targets"
+          placeholder="Search targets..."
+          value={query}
+          onChange={(event) => {
+            onQueryChange(event.target.value)
+          }}
+          onKeyDown={onInputKeyDown}
+        />
+        <ul className="mt-2 max-h-64 space-y-1 overflow-y-auto">
+          {options.length === 0 ? (
+            <li className="rounded-sm px-2 py-1 text-xs text-muted-foreground">
+              No targets match your search.
+            </li>
+          ) : (
+            options.map((option) => {
+              const isHighlighted = highlightedTargetKey === option.key
+              return (
+                <li key={option.key}>
+                  <button
+                    className={`flex w-full items-center justify-between rounded-sm px-2 py-1 text-left text-sm ${
+                      isHighlighted
+                        ? 'bg-accent text-accent-foreground'
+                        : 'hover:bg-accent/60'
+                    }`}
+                    type="button"
+                    onMouseEnter={() => {
+                      onHighlightTarget(option.key)
+                    }}
+                    onClick={() => {
+                      onSelectTarget(option.key)
+                    }}
+                  >
+                    <span className="inline-flex min-w-0 items-center gap-2">
+                      <span className="truncate">{option.label}</span>
+                      {option.isBoss ? (
+                        <span className="inline-flex items-center gap-1 rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-400">
+                          Boss
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      #{option.id}:{option.instance}
+                    </span>
+                  </button>
+                </li>
+              )
+            })
+          )}
+        </ul>
+        <p className="mt-2 text-xs text-muted-foreground">
+          Enter selects target and updates URL.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/target-search.test.ts
+++ b/apps/web/src/lib/target-search.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for fuzzy target search option ranking.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  type TargetSearchOption,
+  filterTargetSearchOptions,
+} from './target-search'
+
+const targetOptions: TargetSearchOption[] = [
+  {
+    id: 100,
+    instance: 1,
+    key: '100:1',
+    name: 'Patchwerk',
+    label: 'Patchwerk (100)',
+    isBoss: true,
+  },
+  {
+    id: 200,
+    instance: 2,
+    key: '200:2',
+    name: 'Patchwork Construct',
+    label: 'Patchwork Construct (200)',
+    isBoss: false,
+  },
+  {
+    id: 300,
+    instance: 3,
+    key: '300:3',
+    name: 'Hateful Strike Target',
+    label: 'Hateful Strike Target (300)',
+    isBoss: false,
+  },
+  {
+    id: 400,
+    instance: 4,
+    key: '400:4',
+    name: 'Target Dummy Boss',
+    label: 'Target Dummy Boss (400)',
+    isBoss: true,
+  },
+]
+
+describe('filterTargetSearchOptions', () => {
+  it('returns bosses before non-bosses when query is empty', () => {
+    expect(
+      filterTargetSearchOptions(targetOptions, '').map((option) => option.key),
+    ).toEqual(['100:1', '400:4', '200:2', '300:3'])
+  })
+
+  it('prioritizes exact then prefix then fuzzy matches', () => {
+    const results = filterTargetSearchOptions(targetOptions, 'patch')
+
+    expect(results[0]?.key).toBe('100:1')
+    expect(results[1]?.key).toBe('200:2')
+  })
+
+  it('ranks boss targets ahead of non-boss targets within the same match tier', () => {
+    const results = filterTargetSearchOptions(targetOptions, 'target')
+
+    expect(results.map((option) => option.key)).toEqual(['400:4', '300:3'])
+  })
+
+  it('returns fuzzy subsequence matches when direct contains is missing', () => {
+    const results = filterTargetSearchOptions(targetOptions, 'hs target')
+
+    expect(results.map((option) => option.key)).toEqual(['300:3'])
+  })
+})

--- a/apps/web/src/lib/target-search.ts
+++ b/apps/web/src/lib/target-search.ts
@@ -1,0 +1,98 @@
+/**
+ * Fuzzy target search helpers used by fight-page keyboard interactions.
+ */
+import { resolveFuzzyMatchScore } from './player-search'
+
+export interface TargetSearchOption {
+  id: number
+  instance: number
+  key: string
+  name: string
+  label: string
+  isBoss: boolean
+}
+
+type MatchTier = 0 | 1 | 2
+
+function resolveMatchTier(score: number): MatchTier {
+  if (score >= 5000) {
+    return 0
+  }
+
+  if (score >= 4000) {
+    return 1
+  }
+
+  return 2
+}
+
+/** Filter and rank target search options with exact/prefix/fuzzy match priority. */
+export function filterTargetSearchOptions(
+  options: TargetSearchOption[],
+  query: string,
+): TargetSearchOption[] {
+  const normalizedQuery = query.trim()
+  if (normalizedQuery.length === 0) {
+    return [...options].sort((left, right) => {
+      if (left.isBoss !== right.isBoss) {
+        return left.isBoss ? -1 : 1
+      }
+
+      return 0
+    })
+  }
+
+  return options
+    .map((option, index) => {
+      const nameScore = resolveFuzzyMatchScore(normalizedQuery, option.name)
+      const labelScore = resolveFuzzyMatchScore(normalizedQuery, option.label)
+      const score =
+        nameScore === null
+          ? labelScore
+          : labelScore === null
+            ? nameScore
+            : Math.max(nameScore, labelScore)
+
+      if (score === null) {
+        return {
+          index,
+          option,
+          score,
+          tier: null,
+        }
+      }
+
+      return {
+        index,
+        option,
+        score,
+        tier: resolveMatchTier(score),
+      }
+    })
+    .filter(
+      (
+        item,
+      ): item is {
+        option: TargetSearchOption
+        index: number
+        score: number
+        tier: MatchTier
+      } => item.score !== null && item.tier !== null,
+    )
+    .sort((left, right) => {
+      if (left.tier !== right.tier) {
+        return left.tier - right.tier
+      }
+
+      if (left.option.isBoss !== right.option.isBoss) {
+        return left.option.isBoss ? -1 : 1
+      }
+
+      if (left.score !== right.score) {
+        return right.score - left.score
+      }
+
+      return left.index - right.index
+    })
+    .map((item) => item.option)
+}

--- a/apps/web/src/pages/fight-page.spec.ts
+++ b/apps/web/src/pages/fight-page.spec.ts
@@ -386,6 +386,9 @@ test.describe('fight page', () => {
       fightPage.shortcuts.shortcutListItem('Open player search'),
     ).toBeVisible()
     await expect(
+      fightPage.shortcuts.shortcutListItem('Open target search'),
+    ).toBeVisible()
+    await expect(
       fightPage.shortcuts.shortcutKey('Cycle boss damage markers', 'B'),
     ).toBeVisible()
     await expect(
@@ -403,8 +406,44 @@ test.describe('fight page', () => {
     await expect(
       fightPage.shortcuts.shortcutKey('Open player search', '/'),
     ).toBeVisible()
+    await expect(
+      fightPage.shortcuts.shortcutKey('Open target search', 'T'),
+    ).toBeVisible()
     await fightPage.shortcuts.closeWithEscape()
     await expect(fightPage.shortcuts.dialog()).toHaveCount(0)
+  })
+
+  test('supports fuzzy target selector keyboard shortcut and immediate navigation', async ({
+    page,
+  }) => {
+    const fightPage = new FightPageObject(page)
+
+    await fightPage.goto(svgFightUrl)
+
+    const targetSearch = page.getByRole('dialog', {
+      name: 'Target search',
+    })
+
+    await expect(targetSearch).toHaveCount(0)
+    await page.keyboard.press('t')
+    await expect(targetSearch).toBeVisible()
+
+    const targetSearchInput = targetSearch.getByRole('textbox', {
+      name: 'Search targets',
+    })
+    await targetSearchInput.fill('hateful')
+    await page.keyboard.press('Enter')
+    await expect(targetSearch).toHaveCount(0)
+
+    await expect(fightPage.chart.targetControl()).toContainText(
+      'Hateful Strike Target (102)',
+    )
+    await expectSearchParam(page, 'targetId', '102')
+
+    await page.keyboard.press('t')
+    await expect(targetSearch).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(targetSearch).toHaveCount(0)
   })
 
   test('focusing a player shows total threat values', async ({ page }) => {

--- a/apps/web/src/pages/fight-page.tsx
+++ b/apps/web/src/pages/fight-page.tsx
@@ -2,11 +2,19 @@
  * Fight-level page with target filter and player-focused chart interactions.
  */
 import { ExternalLink } from 'lucide-react'
-import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  type FC,
+  type KeyboardEventHandler,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import { useHotkeys, useHotkeysContext } from 'react-hotkeys-hook'
 import { useLocation, useParams } from 'react-router-dom'
 
 import { ErrorState } from '../components/error-state'
+import { FightTargetSearch } from '../components/fight-target-search'
 import { PlayerSummaryTable } from '../components/player-summary-table'
 import { SectionCard } from '../components/section-card'
 import { TargetSelector } from '../components/target-selector'
@@ -17,6 +25,7 @@ import { useFightData } from '../hooks/use-fight-data'
 import { useFightEvents } from '../hooks/use-fight-events'
 import { useUserSettings } from '../hooks/use-user-settings'
 import { formatClockDuration } from '../lib/format'
+import { filterTargetSearchOptions } from '../lib/target-search'
 import { resolveCurrentThreatConfig } from '../lib/threat-config'
 import { buildCharacterUrl, buildFightRankingsUrl } from '../lib/wcl-url'
 import { useReportRouteContext } from '../routes/report-layout-context'
@@ -43,6 +52,28 @@ const FightPageLoadingSkeleton: FC = () => {
       </SectionCard>
     </section>
   )
+}
+
+const interactiveTagNames = new Set(['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'])
+
+function isInteractiveElement(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  if (target.isContentEditable) {
+    return true
+  }
+
+  const closestInteractive = target.closest(
+    '[role="button"],[role="checkbox"],[role="combobox"],[role="menuitem"],[role="radio"],[role="switch"],[role="textbox"],button,input,select,textarea,[contenteditable="true"]',
+  )
+
+  if (closestInteractive instanceof HTMLElement) {
+    return true
+  }
+
+  return interactiveTagNames.has(target.tagName)
 }
 
 const FightChartLoadingSkeleton: FC<{
@@ -174,12 +205,121 @@ export const FightPage: FC = () => {
   const [registeredResetZoom, setRegisteredResetZoom] = useState<
     (() => void) | null
   >(null)
+  const [isTargetSearchOpen, setIsTargetSearchOpen] = useState(false)
+  const [targetSearchQuery, setTargetSearchQuery] = useState('')
+  const [highlightedTargetKey, setHighlightedTargetKey] = useState<
+    string | null
+  >(null)
 
   const handleRegisterResetZoom = useCallback(
     (resetZoom: (() => void) | null): void => {
       setRegisteredResetZoom(() => resetZoom)
     },
     [],
+  )
+
+  const filteredTargetOptions = useMemo(
+    () => filterTargetSearchOptions(targetOptions, targetSearchQuery),
+    [targetOptions, targetSearchQuery],
+  )
+
+  const closeTargetSearch = useCallback((): void => {
+    setIsTargetSearchOpen(false)
+    setTargetSearchQuery('')
+    setHighlightedTargetKey(null)
+  }, [])
+
+  const selectTargetByKey = useCallback(
+    (targetKey: string): void => {
+      const selectedOption = targetOptions.find(
+        (target) => target.key === targetKey,
+      )
+      if (!selectedOption) {
+        return
+      }
+
+      handleTargetChange({
+        id: selectedOption.id,
+        instance: selectedOption.instance,
+      })
+      closeTargetSearch()
+    },
+    [closeTargetSearch, handleTargetChange, targetOptions],
+  )
+
+  const handleTargetSearchInputKeyDown = useCallback<
+    KeyboardEventHandler<HTMLInputElement>
+  >(
+    (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        closeTargetSearch()
+        return
+      }
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        if (filteredTargetOptions.length === 0) {
+          return
+        }
+
+        const currentIndex = filteredTargetOptions.findIndex(
+          (target) => target.key === highlightedTargetKey,
+        )
+        const nextIndex =
+          currentIndex < 0
+            ? 0
+            : (currentIndex + 1) % filteredTargetOptions.length
+        const nextTarget = filteredTargetOptions[nextIndex]
+        if (!nextTarget) {
+          return
+        }
+
+        setHighlightedTargetKey(nextTarget.key)
+        return
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        if (filteredTargetOptions.length === 0) {
+          return
+        }
+
+        const currentIndex = filteredTargetOptions.findIndex(
+          (target) => target.key === highlightedTargetKey,
+        )
+        const nextIndex =
+          currentIndex < 0
+            ? filteredTargetOptions.length - 1
+            : (currentIndex - 1 + filteredTargetOptions.length) %
+              filteredTargetOptions.length
+        const nextTarget = filteredTargetOptions[nextIndex]
+        if (!nextTarget) {
+          return
+        }
+
+        setHighlightedTargetKey(nextTarget.key)
+        return
+      }
+
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        const selectedOption =
+          filteredTargetOptions.find(
+            (target) => target.key === highlightedTargetKey,
+          ) ?? filteredTargetOptions[0]
+
+        if (selectedOption) {
+          selectTargetByKey(selectedOption.key)
+        }
+      }
+    },
+    [
+      closeTargetSearch,
+      filteredTargetOptions,
+      highlightedTargetKey,
+      selectTargetByKey,
+    ],
   )
 
   useEffect(() => {
@@ -245,6 +385,45 @@ export const FightPage: FC = () => {
       scopes: ['fight-page'],
     },
     [handleShowEnergizeEventsChange, userSettings.showEnergizeEvents],
+  )
+
+  useHotkeys(
+    't',
+    (event) => {
+      if (isInteractiveElement(event.target)) {
+        return
+      }
+
+      event.preventDefault()
+      const firstOption =
+        filterTargetSearchOptions(targetOptions, '')[0] ?? null
+      setIsTargetSearchOpen(true)
+      setTargetSearchQuery('')
+      setHighlightedTargetKey(firstOption?.key ?? null)
+    },
+    {
+      description: 'Open target search',
+      metadata: {
+        order: 70,
+        showInFightOverlay: true,
+      },
+      scopes: ['fight-page'],
+      useKey: true,
+    },
+    [filteredTargetOptions],
+  )
+
+  useHotkeys(
+    'escape',
+    (event) => {
+      event.preventDefault()
+      closeTargetSearch()
+    },
+    {
+      enabled: isTargetSearchOpen,
+      scopes: ['fight-page'],
+    },
+    [closeTargetSearch, isTargetSearchOpen],
   )
 
   if (!reportId || Number.isNaN(fightId)) {
@@ -413,6 +592,23 @@ export const FightPage: FC = () => {
           <ThreatChart {...chartProps} />
         )}
       </SectionCard>
+
+      <FightTargetSearch
+        isOpen={isTargetSearchOpen}
+        query={targetSearchQuery}
+        options={filteredTargetOptions}
+        highlightedTargetKey={highlightedTargetKey}
+        onClose={closeTargetSearch}
+        onQueryChange={(query) => {
+          setTargetSearchQuery(query)
+          const firstOption =
+            filterTargetSearchOptions(targetOptions, query)[0] ?? null
+          setHighlightedTargetKey(firstOption?.key ?? null)
+        }}
+        onInputKeyDown={handleTargetSearchInputKeyDown}
+        onHighlightTarget={setHighlightedTargetKey}
+        onSelectTarget={selectTargetByKey}
+      />
 
       {!isUserSettingsLoading && eventsData ? (
         <SectionCard


### PR DESCRIPTION
### Motivation

- Provide a keyboard-driven fuzzy target picker on the fight page to quickly switch targets and improve navigation ergonomics.

### Description

- Add `apps/web/src/lib/target-search.ts` implementing `filterTargetSearchOptions` that ranks exact, prefix, and fuzzy matches and prefers bosses within match tiers. 
- Add `apps/web/src/components/fight-target-search.tsx` to render the modal overlay and option list with keyboard/mouse interactions. 
- Integrate the picker into `apps/web/src/pages/fight-page.tsx` with state, `t` hotkey (skipping interactive elements), keyboard navigation (`ArrowUp/Down`, `Enter`, `Escape`), selection logic that calls `handleTargetChange`, and helper `isInteractiveElement`. 
- Add unit tests `apps/web/src/lib/target-search.test.ts` and update `apps/web/src/pages/fight-page.spec.ts` to cover the new shortcut and navigation behavior. 
- Remove the stale `WEB-017` TODO entry from `TODO.md`.

### Testing

- Ran unit tests with `pnpm --filter @wow-threat/web test` (Vitest) and they passed.
- Ran Playwright spec `pnpm --filter @wow-threat/web exec playwright test src/pages/fight-page.spec.ts` and the new target-search scenarios passed.
- Ran linter and type checks with `pnpm --filter @wow-threat/web lint` and `pnpm --filter @wow-threat/web typecheck` and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a930eea5c88332abbf38bcfb583499)