### PR TITLE
Add fuzzy fight search (hotkey F) with navigation preservation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,6 @@
 | WEB-015 | `@wow-threat/web`    | READY       | P2       | S    | Isolate key toggles between isolated and previous players |
 | WEB-016 | `@wow-threat/web`    | READY       | P2       | S    | Zoom key toggles between no zoom and previous zoom        |
 | WEB-017 | `@wow-threat/web`    | READY       | P2       | M    | Fuzzy target selector                                     |
-| WEB-018 | `@wow-threat/web`    | READY       | P2       | M    | Fuzzy fight selector                                      |
 | WEB-019 | `@wow-threat/web`    | READY       | P0       | M    | Fight event pagination currently blocks the UI thread     |
 | WEB-021 | `@wow-threat/web`    | READY       | P2       | S    | Keyboard shortcut for filter to tanks only                |
 | WEB-027 | `@wow-threat/web`    | READY       | P3       | XS   | Make toggled players in legend more prominent             |
@@ -208,39 +207,6 @@ validation:
   - pnpm --filter @wow-threat/web test
 branch_name: codex/web-017-fuzzy-target-selector
 worktree_path: ../wow-threat-web-017
-publish: auto_push_pr
-pr_url: null
-commit_sha: null
-```
-
-### WEB-018 - Fuzzy fight selector
-
-```yaml
-id: WEB-018
-title: Fuzzy fight selector
-package: @wow-threat/web
-status: READY
-priority: P2
-size: M
-depends_on: []
-files_hint:
-  - apps/web/src/pages/report-page.tsx
-  - apps/web/src/lib/fight-navigation.ts
-  - apps/web/src/pages/report-page.spec.ts
-acceptance_criteria:
-  - Pressing f opens a fuzzy fight selector on report and fight pages where quick-switch navigation is available, when not focused in input/control context.
-  - Fuzzy selector coexists with the existing quick-switch UI.
-  - Candidate set includes all fights (boss kills, boss wipes, and trash fights).
-  - Fight results display kill/wipe status, with wipes visually de-emphasized.
-  - Ranking priority is exact match, then prefix match, then fuzzy match by fight/boss name.
-  - Selecting a fight navigates immediately and closes the picker.
-  - Selection behavior matches quick-switch links: preserve pinned-player behavior and reset other transient query params.
-validation:
-  - pnpm --filter @wow-threat/web lint
-  - pnpm --filter @wow-threat/web typecheck
-  - pnpm --filter @wow-threat/web test
-branch_name: codex/web-018-fuzzy-fight-selector
-worktree_path: ../wow-threat-web-018
 publish: auto_push_pr
 pr_url: null
 commit_sha: null

--- a/apps/web/src/components/fight-quick-switcher.tsx
+++ b/apps/web/src/components/fight-quick-switcher.tsx
@@ -4,7 +4,10 @@
 import type { FC } from 'react'
 import { Link } from 'react-router-dom'
 
-import { buildBossKillNavigationFights } from '../lib/fight-navigation'
+import {
+  buildBossKillNavigationFights,
+  buildFightNavigationPath,
+} from '../lib/fight-navigation'
 import type { ReportFightSummary } from '../types/api'
 
 export type FightQuickSwitcherProps = {
@@ -22,9 +25,6 @@ export const FightQuickSwitcher: FC<FightQuickSwitcherProps> = ({
   pinnedPlayerIds = [],
 }) => {
   const bossKillFights = buildBossKillNavigationFights(fights)
-  const pinnedPlayers = [...new Set(pinnedPlayerIds)].sort(
-    (left, right) => left - right,
-  )
 
   return (
     <nav aria-label="Fight quick switch">
@@ -32,13 +32,6 @@ export const FightQuickSwitcher: FC<FightQuickSwitcherProps> = ({
         <div className="flex w-full gap-1 overflow-x-auto">
           {bossKillFights.map((fight) => {
             const isCurrentFight = fight.id === selectedFightId
-            const searchParams = new URLSearchParams()
-            if (pinnedPlayers.length > 0) {
-              const pinnedPlayerParam = pinnedPlayers.join(',')
-              searchParams.set('pinnedPlayers', pinnedPlayerParam)
-              searchParams.set('players', pinnedPlayerParam)
-            }
-            const search = searchParams.toString()
 
             return (
               <Link
@@ -49,7 +42,11 @@ export const FightQuickSwitcher: FC<FightQuickSwitcherProps> = ({
                     : 'text-foreground/60 hover:text-foreground',
                 ].join(' ')}
                 key={fight.id}
-                to={`/report/${reportId}/fight/${fight.id}${search.length > 0 ? `?${search}` : ''}`}
+                to={buildFightNavigationPath({
+                  reportId,
+                  fightId: fight.id,
+                  pinnedPlayerIds,
+                })}
               >
                 {fight.name}
               </Link>

--- a/apps/web/src/components/fight-search-dialog.tsx
+++ b/apps/web/src/components/fight-search-dialog.tsx
@@ -1,0 +1,111 @@
+/**
+ * Fuzzy fight selector dialog for report and fight routes.
+ */
+import type { KeyboardEventHandler } from 'react'
+
+import type { FightSearchOption } from '../lib/fight-search'
+import { Input } from './ui/input'
+import { Kbd } from './ui/kbd'
+
+export interface FightSearchDialogProps {
+  isOpen: boolean
+  query: string
+  options: FightSearchOption[]
+  highlightedFightId: number | null
+  onClose: () => void
+  onQueryChange: (query: string) => void
+  onInputKeyDown: KeyboardEventHandler<HTMLInputElement>
+  onHighlightFight: (fightId: number) => void
+  onSelectFight: (fightId: number) => void
+}
+
+/** Render keyboard-driven fight picker with fuzzy query matching. */
+export function FightSearchDialog({
+  isOpen,
+  query,
+  options,
+  highlightedFightId,
+  onClose,
+  onQueryChange,
+  onInputKeyDown,
+  onHighlightFight,
+  onSelectFight,
+}: FightSearchDialogProps) {
+  if (!isOpen) {
+    return null
+  }
+
+  return (
+    <div
+      aria-label="Fight search"
+      aria-modal="false"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 p-4"
+      role="dialog"
+      onClick={() => {
+        onClose()
+      }}
+    >
+      <div
+        className="w-full max-w-md rounded-lg border border-border bg-card p-3 shadow-lg"
+        onClick={(event) => {
+          event.stopPropagation()
+        }}
+      >
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold">Fight search</h2>
+          <Kbd>F</Kbd>
+        </div>
+        <Input
+          autoFocus
+          aria-label="Search fights"
+          placeholder="Search fights..."
+          value={query}
+          onChange={(event) => {
+            onQueryChange(event.target.value)
+          }}
+          onKeyDown={onInputKeyDown}
+        />
+        <ul className="mt-2 max-h-56 space-y-1 overflow-y-auto">
+          {options.length === 0 ? (
+            <li className="rounded-sm px-2 py-1 text-xs text-muted-foreground">
+              No fights match your search.
+            </li>
+          ) : (
+            options.map((option) => {
+              const isHighlighted = highlightedFightId === option.id
+              return (
+                <li key={option.id}>
+                  <button
+                    className={`flex w-full items-center justify-between rounded-sm px-2 py-1 text-left text-sm ${
+                      isHighlighted
+                        ? 'bg-accent text-accent-foreground'
+                        : 'hover:bg-accent/60'
+                    }`}
+                    type="button"
+                    onMouseEnter={() => {
+                      onHighlightFight(option.id)
+                    }}
+                    onClick={() => {
+                      onSelectFight(option.id)
+                    }}
+                  >
+                    <span className="truncate">{option.name}</span>
+                    <span
+                      className={
+                        option.kill
+                          ? 'text-xs'
+                          : 'text-xs text-muted-foreground'
+                      }
+                    >
+                      {option.kill ? 'Kill' : 'Wipe'}
+                    </span>
+                  </button>
+                </li>
+              )
+            })
+          )}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/hooks/use-fight-search.ts
+++ b/apps/web/src/hooks/use-fight-search.ts
@@ -1,0 +1,138 @@
+/**
+ * State and keyboard interactions for report/fight fuzzy fight search dialog.
+ */
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react'
+
+import {
+  buildFightSearchOptions,
+  filterFightSearchOptions,
+} from '../lib/fight-search'
+import type { ReportFightSummary } from '../types/api'
+
+export interface UseFightSearchResult {
+  isOpen: boolean
+  query: string
+  options: ReturnType<typeof filterFightSearchOptions>
+  highlightedFightId: number | null
+  open: () => void
+  close: () => void
+  setQuery: (query: string) => void
+  setHighlightedFightId: (fightId: number | null) => void
+  handleInputKeyDown: (event: ReactKeyboardEvent<HTMLInputElement>) => void
+  selectFight: (fightId: number) => void
+}
+
+/** Manage fuzzy fight search filtering and keyboard selection state. */
+export function useFightSearch({
+  fights,
+  onSelectFight,
+}: {
+  fights: ReportFightSummary[]
+  onSelectFight: (fightId: number) => void
+}): UseFightSearchResult {
+  const [isOpen, setIsOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [highlightedFightId, setHighlightedFightId] = useState<number | null>(
+    null,
+  )
+
+  const fightOptions = useMemo(() => buildFightSearchOptions(fights), [fights])
+  const options = useMemo(
+    () => filterFightSearchOptions(fightOptions, query),
+    [fightOptions, query],
+  )
+  const resolvedHighlightedFightId = useMemo(() => {
+    const isHighlightedFightVisible = options.some(
+      (option) => option.id === highlightedFightId,
+    )
+    if (isHighlightedFightVisible) {
+      return highlightedFightId
+    }
+
+    return options[0]?.id ?? null
+  }, [options, highlightedFightId])
+
+  const close = useCallback((): void => {
+    setIsOpen(false)
+    setQuery('')
+    setHighlightedFightId(null)
+  }, [])
+
+  const open = useCallback((): void => {
+    setIsOpen(true)
+    setQuery('')
+    setHighlightedFightId(null)
+  }, [])
+
+  const selectFight = useCallback(
+    (fightId: number): void => {
+      onSelectFight(fightId)
+      close()
+    },
+    [close, onSelectFight],
+  )
+
+  const handleInputKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLInputElement>): void => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        close()
+        return
+      }
+
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        const selectedFight =
+          options.find((option) => option.id === resolvedHighlightedFightId) ??
+          options[0]
+        if (!selectedFight) {
+          return
+        }
+
+        selectFight(selectedFight.id)
+        return
+      }
+
+      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+        return
+      }
+
+      event.preventDefault()
+      if (options.length === 0) {
+        return
+      }
+
+      const currentIndex = options.findIndex(
+        (option) => option.id === resolvedHighlightedFightId,
+      )
+      const direction = event.key === 'ArrowDown' ? 1 : -1
+      const nextIndex =
+        currentIndex === -1
+          ? direction === 1
+            ? 0
+            : options.length - 1
+          : (currentIndex + direction + options.length) % options.length
+
+      setHighlightedFightId(options[nextIndex]?.id ?? null)
+    },
+    [close, options, resolvedHighlightedFightId, selectFight],
+  )
+
+  return {
+    isOpen,
+    query,
+    options,
+    highlightedFightId: resolvedHighlightedFightId,
+    open,
+    close,
+    setQuery,
+    setHighlightedFightId,
+    handleInputKeyDown,
+    selectFight,
+  }
+}

--- a/apps/web/src/lib/fight-navigation.test.ts
+++ b/apps/web/src/lib/fight-navigation.test.ts
@@ -5,6 +5,7 @@ import type { ReportFightSummary } from '../types/api'
 import {
   buildBossKillNavigationFights,
   buildFightNavigationGroups,
+  buildFightNavigationPath,
 } from './fight-navigation'
 
 const createFight = (
@@ -227,5 +228,26 @@ describe('buildBossKillNavigationFights', () => {
     const bossKills = buildBossKillNavigationFights(fights)
 
     expect(bossKills.map((fight) => fight.id)).toEqual([81])
+  })
+})
+
+describe('buildFightNavigationPath', () => {
+  it('builds a bare fight path when no pinned players are provided', () => {
+    expect(
+      buildFightNavigationPath({
+        reportId: 'abc123',
+        fightId: 26,
+      }),
+    ).toBe('/report/abc123/fight/26')
+  })
+
+  it('preserves pinned players and mirrors them into players search param', () => {
+    expect(
+      buildFightNavigationPath({
+        reportId: 'abc123',
+        fightId: 30,
+        pinnedPlayerIds: [3, 1, 3],
+      }),
+    ).toBe('/report/abc123/fight/30?pinnedPlayers=1%2C3&players=1%2C3')
   })
 })

--- a/apps/web/src/lib/fight-navigation.ts
+++ b/apps/web/src/lib/fight-navigation.ts
@@ -19,6 +19,12 @@ export interface FightNavigationGroups {
   trashFights: ReportFightSummary[]
 }
 
+export interface FightNavigationPathOptions {
+  reportId: string
+  fightId: number
+  pinnedPlayerIds?: number[]
+}
+
 const unresolvedFightOrder = Number.MAX_SAFE_INTEGER
 
 export const isBossFightForNavigation = (
@@ -233,4 +239,25 @@ export function buildFightNavigationGroups(
     bossEncounters,
     trashFights,
   }
+}
+
+/** Build a fight-route URL that preserves pinned-player navigation behavior. */
+export function buildFightNavigationPath({
+  reportId,
+  fightId,
+  pinnedPlayerIds = [],
+}: FightNavigationPathOptions): string {
+  const pinnedPlayers = [...new Set(pinnedPlayerIds)].sort(
+    (left, right) => left - right,
+  )
+  const searchParams = new URLSearchParams()
+
+  if (pinnedPlayers.length > 0) {
+    const pinnedPlayerParam = pinnedPlayers.join(',')
+    searchParams.set('pinnedPlayers', pinnedPlayerParam)
+    searchParams.set('players', pinnedPlayerParam)
+  }
+
+  const search = searchParams.toString()
+  return `/report/${reportId}/fight/${fightId}${search.length > 0 ? `?${search}` : ''}`
 }

--- a/apps/web/src/lib/fight-search.test.ts
+++ b/apps/web/src/lib/fight-search.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Unit tests for report/fight fuzzy fight search helpers.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { filterFightSearchOptions } from './fight-search'
+
+describe('filterFightSearchOptions', () => {
+  const options = [
+    { id: 1, kill: true, name: 'Patchwerk' },
+    { id: 2, kill: false, name: 'Naxxramas Trash' },
+    { id: 3, kill: true, name: 'Grobbulus' },
+  ]
+
+  it('ranks exact matches above prefix and fuzzy matches', () => {
+    const ranked = filterFightSearchOptions(options, 'patchwerk')
+
+    expect(ranked[0]?.id).toBe(1)
+  })
+
+  it('ranks prefix matches above fuzzy subsequence matches', () => {
+    const ranked = filterFightSearchOptions(options, 'grob')
+
+    expect(ranked[0]?.id).toBe(3)
+    expect(filterFightSearchOptions(options, 'pwrk')[0]?.id).toBe(1)
+  })
+
+  it('returns empty array for unmatched query', () => {
+    expect(filterFightSearchOptions(options, 'zzzz')).toEqual([])
+  })
+})

--- a/apps/web/src/lib/fight-search.ts
+++ b/apps/web/src/lib/fight-search.ts
@@ -1,0 +1,53 @@
+/**
+ * Fuzzy fight search helpers for report/fight quick-switch keyboard picker.
+ */
+import type { ReportFightSummary } from '../types/api'
+import { resolveFuzzyMatchScore } from './player-search'
+
+export interface FightSearchOption {
+  id: number
+  name: string
+  kill: boolean
+}
+
+export function buildFightSearchOptions(
+  fights: ReportFightSummary[],
+): FightSearchOption[] {
+  return fights.map((fight) => ({
+    id: fight.id,
+    name: fight.name,
+    kill: fight.kill,
+  }))
+}
+
+/** Filter and rank fight options by exact, prefix, then fuzzy name matches. */
+export function filterFightSearchOptions(
+  options: FightSearchOption[],
+  rawQuery: string,
+): FightSearchOption[] {
+  const query = rawQuery.trim()
+  if (query.length === 0) {
+    return options
+  }
+
+  return options
+    .map((option, index) => ({
+      option,
+      index,
+      score: resolveFuzzyMatchScore(query, option.name),
+    }))
+    .filter(
+      (
+        item,
+      ): item is { option: FightSearchOption; index: number; score: number } =>
+        item.score !== null,
+    )
+    .sort((left, right) => {
+      if (left.score !== right.score) {
+        return right.score - left.score
+      }
+
+      return left.index - right.index
+    })
+    .map((item) => item.option)
+}

--- a/apps/web/src/pages/fight-page.spec.ts
+++ b/apps/web/src/pages/fight-page.spec.ts
@@ -386,6 +386,9 @@ test.describe('fight page', () => {
       fightPage.shortcuts.shortcutListItem('Open player search'),
     ).toBeVisible()
     await expect(
+      fightPage.shortcuts.shortcutListItem('Open fight search'),
+    ).toBeVisible()
+    await expect(
       fightPage.shortcuts.shortcutKey('Cycle boss damage markers', 'B'),
     ).toBeVisible()
     await expect(
@@ -402,6 +405,9 @@ test.describe('fight page', () => {
     ).toBeVisible()
     await expect(
       fightPage.shortcuts.shortcutKey('Open player search', '/'),
+    ).toBeVisible()
+    await expect(
+      fightPage.shortcuts.shortcutKey('Open fight search', 'F'),
     ).toBeVisible()
     await fightPage.shortcuts.closeWithEscape()
     await expect(fightPage.shortcuts.dialog()).toHaveCount(0)

--- a/apps/web/src/pages/report-page.spec.ts
+++ b/apps/web/src/pages/report-page.spec.ts
@@ -91,4 +91,39 @@ test.describe('report page', () => {
       page.getByRole('region', { name: 'Player navigation' }),
     ).toHaveCount(0)
   })
+
+  test('opens fuzzy fight selector with f and navigates on selection', async ({
+    page,
+  }) => {
+    await page.goto(`/report/${e2eReportId}`)
+
+    await page.keyboard.press('f')
+    await expect(
+      page.getByRole('dialog', { name: 'Fight search' }),
+    ).toBeVisible()
+
+    const searchInput = page.getByRole('textbox', { name: 'Search fights' })
+    await searchInput.fill('trash')
+    await searchInput.press('Enter')
+
+    await expectPathname(page, `/report/${e2eReportId}/fight/40`)
+    await expect(
+      page.getByRole('dialog', { name: 'Fight search' }),
+    ).toHaveCount(0)
+  })
+
+  test('does not open fuzzy fight selector when typing in an input control', async ({
+    page,
+  }) => {
+    await page.goto(`/report/${e2eReportId}`)
+
+    await page.getByRole('button', { name: 'Open report input' }).click()
+    const reportInput = page.getByRole('combobox', { name: 'Open report' })
+    await reportInput.click()
+    await page.keyboard.press('f')
+
+    await expect(
+      page.getByRole('dialog', { name: 'Fight search' }),
+    ).toHaveCount(0)
+  })
 })

--- a/apps/web/src/routes/report-layout.tsx
+++ b/apps/web/src/routes/report-layout.tsx
@@ -2,18 +2,24 @@
  * Shared report route layout with compact header and fight quick switcher.
  */
 import { type FC, useEffect } from 'react'
-import { Outlet, useLocation, useParams } from 'react-router-dom'
+import { useHotkeys } from 'react-hotkeys-hook'
+import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { ErrorState } from '../components/error-state'
 import { FightQuickSwitcher } from '../components/fight-quick-switcher'
+import { FightSearchDialog } from '../components/fight-search-dialog'
 import {
   ReportSummaryHeader,
   ReportSummaryHeaderSkeleton,
 } from '../components/report-summary-header'
+import { useFightSearch } from '../hooks/use-fight-search'
 import { useReportData } from '../hooks/use-report-data'
 import { useReportIndex } from '../hooks/use-report-index'
 import { useUserSettings } from '../hooks/use-user-settings'
-import { buildBossKillNavigationFights } from '../lib/fight-navigation'
+import {
+  buildBossKillNavigationFights,
+  buildFightNavigationPath,
+} from '../lib/fight-navigation'
 import { parsePlayersParam } from '../lib/search-params'
 import { resolveCurrentThreatConfig } from '../lib/threat-config'
 import type { WarcraftLogsHost } from '../types/app'
@@ -28,6 +34,7 @@ export const ReportLayout: FC = () => {
   const params = useParams<{ reportId: string; fightId?: string }>()
   const reportId = params.reportId ?? ''
   const fightId = Number.parseInt(params.fightId ?? '', 10)
+  const navigate = useNavigate()
 
   const location = useLocation()
   const locationState = location.state as LocationState | null
@@ -45,6 +52,59 @@ export const ReportLayout: FC = () => {
   const fallbackHost = resolveReportHost(reportId)
   const reportHost = locationState?.host ?? fallbackHost
   const { data, isLoading, error } = useReportData(reportId)
+  const {
+    isOpen: isFightSearchOpen,
+    query: fightSearchQuery,
+    options: fightSearchOptions,
+    highlightedFightId,
+    open: openFightSearch,
+    close: closeFightSearch,
+    setQuery: setFightSearchQuery,
+    setHighlightedFightId,
+    handleInputKeyDown,
+    selectFight,
+  } = useFightSearch({
+    fights: data?.fights ?? [],
+    onSelectFight: (selectedId) => {
+      navigate(
+        buildFightNavigationPath({
+          reportId,
+          fightId: selectedId,
+          pinnedPlayerIds,
+        }),
+      )
+    },
+  })
+
+  useHotkeys(
+    'f',
+    (event) => {
+      if (!event.target) {
+        return
+      }
+
+      const targetElement = event.target as HTMLElement
+      if (
+        targetElement.closest(
+          'input, textarea, select, button, [contenteditable]',
+        )
+      ) {
+        return
+      }
+
+      event.preventDefault()
+      openFightSearch()
+    },
+    {
+      description: 'Open fight search',
+      enableOnFormTags: false,
+      metadata: {
+        order: 65,
+        showInFightOverlay: true,
+      },
+    },
+    [openFightSearch],
+  )
 
   useEffect(() => {
     if (!data) {
@@ -128,6 +188,17 @@ export const ReportLayout: FC = () => {
         pinnedPlayerIds={pinnedPlayerIds}
         reportId={reportId}
         selectedFightId={selectedFightId}
+      />
+      <FightSearchDialog
+        highlightedFightId={highlightedFightId}
+        isOpen={isFightSearchOpen}
+        options={fightSearchOptions}
+        query={fightSearchQuery}
+        onClose={closeFightSearch}
+        onHighlightFight={setHighlightedFightId}
+        onInputKeyDown={handleInputKeyDown}
+        onQueryChange={setFightSearchQuery}
+        onSelectFight={selectFight}
       />
       <Outlet context={outletContext} />
     </div>


### PR DESCRIPTION
### Motivation

- Provide a keyboard-driven fuzzy fight picker for reports/fight pages to quickly jump between fights without disturbing pinned-player navigation state.
- Preserve existing pinned-player behavior when navigating to a selected fight and ensure the quick-switcher reuses the same URL logic.

### Description

- Add a `FightSearchDialog` component and `useFightSearch` hook to render and manage a keyboard-driven fuzzy fight picker with highlight, enter selection, and escape behavior.
- Implement fuzzy search helpers in `lib/fight-search.ts` and reuse `resolveFuzzyMatchScore` for ranking, and add unit tests in `fight-search.test.ts` to validate ranking behavior.
- Introduce `buildFightNavigationPath` in `lib/fight-navigation.ts` to construct fight route URLs that preserve deduplicated `pinnedPlayers` and mirror them into `players`, update `FightQuickSwitcher` to use it, and add tests in `fight-navigation.test.ts` for the new path builder.
- Wire the dialog into `report-layout.tsx`, add a global hotkey binding for `f` (ignoring input/control contexts), and update Playwright specs (`report-page.spec.ts`, `fight-page.spec.ts`) to assert the new shortcut and dialog behavior; also remove the WEB-018 TODO entry in `TODO.md`.

### Testing

- Ran `pnpm --filter @wow-threat/web lint` and `pnpm --filter @wow-threat/web typecheck` which passed without errors.
- Ran unit tests via `pnpm --filter @wow-threat/web test`, which included the new `fight-search.test.ts` and updated `fight-navigation.test.ts`, and all tests passed.
- Updated Playwright specs (`report-page.spec.ts`, `fight-page.spec.ts`) to cover opening the dialog with `f`, selecting a fight, and ensuring it does not open while focused in inputs, and the e2e checks passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a93105ae2883328229d4b262f8c6d6)