### PR TITLE
fix(web): preserve fresh query param across fight selector

### DIFF
--- a/apps/web/src/components/fight-quick-switcher.test.tsx
+++ b/apps/web/src/components/fight-quick-switcher.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Component tests for fight quick-switch query-param behavior.
+ */
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import type { ReportFightSummary } from '../types/api'
+import { FightQuickSwitcher } from './fight-quick-switcher'
+
+const fights: ReportFightSummary[] = [
+  {
+    id: 26,
+    encounterID: 1001,
+    classicSeasonID: 3,
+    name: 'Patchwerk',
+    startTime: 1000,
+    endTime: 2000,
+    kill: true,
+    difficulty: 3,
+    bossPercentage: null,
+    fightPercentage: null,
+    enemyNPCs: [],
+    enemyPets: [],
+    friendlyPlayers: [1, 2, 3],
+    friendlyPets: [],
+  },
+  {
+    id: 30,
+    encounterID: 1002,
+    classicSeasonID: 3,
+    name: 'Grobbulus',
+    startTime: 3000,
+    endTime: 4000,
+    kill: true,
+    difficulty: 3,
+    bossPercentage: null,
+    fightPercentage: null,
+    enemyNPCs: [],
+    enemyPets: [],
+    friendlyPlayers: [1, 2, 3],
+    friendlyPets: [],
+  },
+]
+
+describe('FightQuickSwitcher', () => {
+  it('keeps fresh query param when forceFresh is enabled', () => {
+    render(
+      <MemoryRouter>
+        <FightQuickSwitcher
+          fights={fights}
+          forceFresh
+          reportId="ABC123"
+          selectedFightId={26}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('link', { name: 'Grobbulus' })).toHaveAttribute(
+      'href',
+      '/report/ABC123/fight/30?fresh=1',
+    )
+  })
+
+  it('keeps fresh alongside pinned player params', () => {
+    render(
+      <MemoryRouter>
+        <FightQuickSwitcher
+          fights={fights}
+          forceFresh
+          pinnedPlayerIds={[2, 1, 2]}
+          reportId="ABC123"
+          selectedFightId={26}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('link', { name: 'Grobbulus' })).toHaveAttribute(
+      'href',
+      '/report/ABC123/fight/30?fresh=1&pinnedPlayers=1%2C2&players=1%2C2',
+    )
+  })
+})

--- a/apps/web/src/components/fight-quick-switcher.tsx
+++ b/apps/web/src/components/fight-quick-switcher.tsx
@@ -12,6 +12,7 @@ export type FightQuickSwitcherProps = {
   fights: ReportFightSummary[]
   selectedFightId: number | null
   pinnedPlayerIds?: number[]
+  forceFresh?: boolean
 }
 
 /** Render boss-kill quick links in report order. */
@@ -20,6 +21,7 @@ export const FightQuickSwitcher: FC<FightQuickSwitcherProps> = ({
   fights,
   selectedFightId,
   pinnedPlayerIds = [],
+  forceFresh = false,
 }) => {
   const bossKillFights = buildBossKillNavigationFights(fights)
   const pinnedPlayers = [...new Set(pinnedPlayerIds)].sort(
@@ -33,6 +35,9 @@ export const FightQuickSwitcher: FC<FightQuickSwitcherProps> = ({
           {bossKillFights.map((fight) => {
             const isCurrentFight = fight.id === selectedFightId
             const searchParams = new URLSearchParams()
+            if (forceFresh) {
+              searchParams.set('fresh', '1')
+            }
             if (pinnedPlayers.length > 0) {
               const pinnedPlayerParam = pinnedPlayers.join(',')
               searchParams.set('pinnedPlayers', pinnedPlayerParam)

--- a/apps/web/src/lib/query-params.test.ts
+++ b/apps/web/src/lib/query-params.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Unit tests for shared URL query-param parsing helpers.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { parseBooleanQueryParam } from './query-params'
+
+describe('query-params', () => {
+  it('parses 1 and true values as true', () => {
+    expect(parseBooleanQueryParam('1')).toBe(true)
+    expect(parseBooleanQueryParam('true')).toBe(true)
+    expect(parseBooleanQueryParam(' TrUe ')).toBe(true)
+  })
+
+  it('parses false values as false', () => {
+    expect(parseBooleanQueryParam('false')).toBe(false)
+    expect(parseBooleanQueryParam(' FALSE ')).toBe(false)
+    expect(parseBooleanQueryParam('0')).toBe(false)
+  })
+
+  it('returns null for missing or unsupported values', () => {
+    expect(parseBooleanQueryParam(null)).toBeNull()
+    expect(parseBooleanQueryParam('')).toBeNull()
+    expect(parseBooleanQueryParam('yes')).toBeNull()
+  })
+})

--- a/apps/web/src/lib/query-params.ts
+++ b/apps/web/src/lib/query-params.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared URL query-param parsing helpers.
+ */
+
+const truthyBooleanParamValues = new Set(['1', 'true'])
+const falsyBooleanParamValues = new Set(['0', 'false'])
+
+/** Parse a boolean-like query-param value into true/false/null. */
+export function parseBooleanQueryParam(value: string | null): boolean | null {
+  if (!value) {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (truthyBooleanParamValues.has(normalized)) {
+    return true
+  }
+
+  if (falsyBooleanParamValues.has(normalized)) {
+    return false
+  }
+
+  return null
+}

--- a/apps/web/src/pages/fight-page-settings.test.tsx
+++ b/apps/web/src/pages/fight-page-settings.test.tsx
@@ -213,4 +213,92 @@ describe('FightPage inferThreatReduction startup behavior', () => {
       true,
     )
   })
+
+  it('passes forceFresh when fresh=true is present in fight URL query params', () => {
+    useFightDataMock.mockReturnValue({
+      data: null,
+      error: null,
+      isLoading: true,
+    })
+    useUserSettingsMock.mockReturnValue({
+      error: null,
+      isLoading: false,
+      isSaving: false,
+      settings: {
+        inferThreatReduction: true,
+        showBossMelee: true,
+        showAllBossDamageEvents: false,
+        showFixateBands: true,
+        showEnergizeEvents: false,
+        showPets: false,
+      },
+      updateSettings: vi.fn(),
+    })
+
+    render(
+      <MemoryRouter
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+        initialEntries={['/report/WaxMPvZrAHT9gJhc/fight/9?fresh=true']}
+      >
+        <Routes>
+          <Route
+            path="/report/:reportId/fight/:fightId"
+            element={<FightPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(useFightEventsMock).toHaveBeenCalledWith(
+      'WaxMPvZrAHT9gJhc',
+      9,
+      true,
+      true,
+      true,
+    )
+  })
+
+  it('does not pass forceFresh when fresh=false is present in fight URL query params', () => {
+    useFightDataMock.mockReturnValue({
+      data: null,
+      error: null,
+      isLoading: true,
+    })
+    useUserSettingsMock.mockReturnValue({
+      error: null,
+      isLoading: false,
+      isSaving: false,
+      settings: {
+        inferThreatReduction: true,
+        showBossMelee: true,
+        showAllBossDamageEvents: false,
+        showFixateBands: true,
+        showEnergizeEvents: false,
+        showPets: false,
+      },
+      updateSettings: vi.fn(),
+    })
+
+    render(
+      <MemoryRouter
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+        initialEntries={['/report/WaxMPvZrAHT9gJhc/fight/9?fresh=false']}
+      >
+        <Routes>
+          <Route
+            path="/report/:reportId/fight/:fightId"
+            element={<FightPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(useFightEventsMock).toHaveBeenCalledWith(
+      'WaxMPvZrAHT9gJhc',
+      9,
+      true,
+      true,
+      false,
+    )
+  })
 })

--- a/apps/web/src/pages/fight-page.spec.ts
+++ b/apps/web/src/pages/fight-page.spec.ts
@@ -211,6 +211,30 @@ test.describe('fight page', () => {
     await expectSearchString(page, '')
   })
 
+  test('quick switch links keep fresh query param when enabled', async ({
+    page,
+  }) => {
+    const fightPage = new FightPageObject(page)
+
+    await fightPage.goto(
+      `${svgFightUrl}&fresh=true&players=1&focusId=1&targetId=102&startMs=1000&endMs=2000`,
+    )
+
+    await expect(fightPage.quickSwitch.fightLink('Grobbulus')).toHaveAttribute(
+      'href',
+      `/report/${e2eReportId}/fight/30?fresh=1`,
+    )
+    await fightPage.quickSwitch.clickFight('Grobbulus')
+
+    await expectPathname(page, `/report/${e2eReportId}/fight/30`)
+    await expectSearchParam(page, 'fresh', '1')
+    await expectSearchParam(page, 'players', null)
+    await expectSearchParam(page, 'focusId', null)
+    await expectSearchParam(page, 'targetId', null)
+    await expectSearchParam(page, 'startMs', null)
+    await expectSearchParam(page, 'endMs', null)
+  })
+
   test('pins players and keeps them on quick switch fight links', async ({
     page,
   }) => {

--- a/apps/web/src/pages/fight-page.tsx
+++ b/apps/web/src/pages/fight-page.tsx
@@ -17,6 +17,7 @@ import { useFightData } from '../hooks/use-fight-data'
 import { useFightEvents } from '../hooks/use-fight-events'
 import { useUserSettings } from '../hooks/use-user-settings'
 import { formatClockDuration } from '../lib/format'
+import { parseBooleanQueryParam } from '../lib/query-params'
 import { resolveCurrentThreatConfig } from '../lib/threat-config'
 import { buildCharacterUrl, buildFightRankingsUrl } from '../lib/wcl-url'
 import { useReportRouteContext } from '../routes/report-layout-context'
@@ -101,7 +102,8 @@ export const FightPage: FC = () => {
       ? 'svg'
       : 'canvas'
   const forceFreshEvents =
-    new URLSearchParams(location.search).get('fresh') === '1'
+    parseBooleanQueryParam(new URLSearchParams(location.search).get('fresh')) ??
+    false
   const {
     settings: userSettings,
     isLoading: isUserSettingsLoading,

--- a/apps/web/src/routes/report-layout.tsx
+++ b/apps/web/src/routes/report-layout.tsx
@@ -14,6 +14,7 @@ import { useReportData } from '../hooks/use-report-data'
 import { useReportIndex } from '../hooks/use-report-index'
 import { useUserSettings } from '../hooks/use-user-settings'
 import { buildBossKillNavigationFights } from '../lib/fight-navigation'
+import { parseBooleanQueryParam } from '../lib/query-params'
 import { parsePlayersParam } from '../lib/search-params'
 import { resolveCurrentThreatConfig } from '../lib/threat-config'
 import type { WarcraftLogsHost } from '../types/app'
@@ -31,9 +32,9 @@ export const ReportLayout: FC = () => {
 
   const location = useLocation()
   const locationState = location.state as LocationState | null
-  const pinnedPlayerIds = parsePlayersParam(
-    new URLSearchParams(location.search).get('pinnedPlayers'),
-  )
+  const queryParams = new URLSearchParams(location.search)
+  const pinnedPlayerIds = parsePlayersParam(queryParams.get('pinnedPlayers'))
+  const forceFresh = parseBooleanQueryParam(queryParams.get('fresh')) ?? false
 
   const { addRecentReport, resolveReportHost } = useReportIndex()
   const {
@@ -139,6 +140,7 @@ export const ReportLayout: FC = () => {
         />
         <FightQuickSwitcher
           fights={data.fights}
+          forceFresh={forceFresh}
           pinnedPlayerIds={pinnedPlayerIds}
           reportId={reportId}
           selectedFightId={selectedFightId}


### PR DESCRIPTION
## Description

- keep the `fresh` query param sticky when switching fights via the report quick switcher
- add a shared web query-param boolean parser and use it for `fresh` URL parsing (`1`/`true`/`false` support)
- add unit and Playwright coverage for fresh parsing and quick-switch link behavior

## Validation

- `pnpm --filter @wow-threat/web lint`
- `pnpm --filter @wow-threat/web typecheck`
- `pnpm --filter @wow-threat/web exec vitest run src/lib/query-params.test.ts src/components/fight-quick-switcher.test.tsx src/pages/fight-page-settings.test.tsx`
- `pnpm --filter @wow-threat/web exec playwright test src/pages/fight-page.spec.ts -g "quick switch links keep fresh query param when enabled" --repeat-each=25`
- `pnpm --filter @wow-threat/web exec playwright test src/pages/fight-page.spec.ts --repeat-each=5`
- `PLAYWRIGHT_SCREENSHOT=1 pnpm --filter @wow-threat/web exec playwright test src/pages/fight-page.spec.ts -g "defaults to the main boss and shows expected players in the legend"`
- `pnpm --filter @wow-threat/web fmt`

## Risks

- Low: quick-switch links now intentionally preserve only `fresh` (plus existing pinned-player params) while still resetting other fight-scoped params.

## Visuals

![Updated fight page quick switch behavior](https://github.com/user-attachments/assets/47aca9a6-0716-4e88-95db-e5d4738536e1)
