### PR TITLE
feat(web): replay mode with playhead scrubber and threat meter

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -127,6 +127,7 @@ Additional component composition guidance:
 - It is fine to keep small UI-local state/effects in the component body when they are tied to DOM/view concerns and do not represent a broader feature workflow.
 - Treat feature boundaries as the primary organizing unit: new logical features should usually keep their state/effects/handlers together in a hook, but avoid extracting trivial one-off logic into hooks unnecessarily.
 - Hook extraction can be private to the component file when reuse is unlikely; prefer clarity and separation of concerns over forcing everything into the component body.
+- Avoid large blocks of inlined JSX. Find natural component boundaries and extract named child components (with descriptive props) within the same file. This applies to repeated items in lists, conditional branches, and any section of markup that has its own logical identity.
 - React Compiler is enabled for this app. Do not add `useMemo` or `useCallback` as default optimization tools.
 - Only add manual memoization when there is a demonstrated correctness or performance need that the compiler does not cover.
 

--- a/apps/web/src/components/fight-page-keyboard-shortcuts-overlay.tsx
+++ b/apps/web/src/components/fight-page-keyboard-shortcuts-overlay.tsx
@@ -9,11 +9,15 @@ import { Kbd, KbdGroup } from './ui/kbd'
 
 interface FightPageKeyboardShortcut {
   description: string
+  group: string
   hotkey: string
   order: number
 }
 
+const DEFAULT_GROUP = 'Chart'
+
 interface ShortcutMetadata {
+  group?: string
   order?: number
   showInFightOverlay?: boolean
 }
@@ -131,6 +135,7 @@ export function FightPageKeyboardShortcutsOverlay({
 
         const shortcut = {
           description: hotkey.description,
+          group: metadata.group ?? DEFAULT_GROUP,
           hotkey: hotkey.hotkey,
           order: metadata.order ?? Number.MAX_SAFE_INTEGER,
         }
@@ -144,17 +149,33 @@ export function FightPageKeyboardShortcutsOverlay({
       new Map<string, FightPageKeyboardShortcut>(),
     )
 
-    return [...shortcutMap.values()].sort((left, right) => {
-      if (left.order !== right.order) {
-        return left.order - right.order
+    const groupMap = new Map<string, FightPageKeyboardShortcut[]>()
+    for (const shortcut of shortcutMap.values()) {
+      const existing = groupMap.get(shortcut.group)
+      if (existing) {
+        existing.push(shortcut)
+      } else {
+        groupMap.set(shortcut.group, [shortcut])
       }
+    }
 
-      if (left.description !== right.description) {
-        return left.description.localeCompare(right.description)
-      }
+    const sortItems = (items: FightPageKeyboardShortcut[]) =>
+      items.sort((left, right) => {
+        if (left.order !== right.order) {
+          return left.order - right.order
+        }
 
-      return left.hotkey.localeCompare(right.hotkey)
-    })
+        if (left.description !== right.description) {
+          return left.description.localeCompare(right.description)
+        }
+
+        return left.hotkey.localeCompare(right.hotkey)
+      })
+
+    return [...groupMap.entries()].map(([name, items]) => ({
+      name,
+      items: sortItems(items),
+    }))
   }, [hotkeys])
 
   if (!isOpen) {
@@ -183,17 +204,26 @@ export function FightPageKeyboardShortcutsOverlay({
             <Kbd>Esc</Kbd>
           </KbdGroup>
         </div>
-        <ul className="space-y-2 text-sm">
-          {shortcuts.map((shortcut) => (
-            <li
-              className="flex items-center justify-between gap-3"
-              key={`${shortcut.description}-${shortcut.hotkey}`}
-            >
-              <span>{shortcut.description}</span>
-              {renderHotkey(shortcut.hotkey)}
-            </li>
+        <div className="space-y-3 text-sm">
+          {shortcuts.map((group, groupIndex) => (
+            <div key={`${group.name}-${groupIndex}`}>
+              <h3 className="mb-1.5 text-xs font-medium text-muted-foreground">
+                {group.name}
+              </h3>
+              <ul className="space-y-2">
+                {group.items.map((shortcut) => (
+                  <li
+                    className="flex items-center justify-between gap-3"
+                    key={`${shortcut.description}-${shortcut.hotkey}`}
+                  >
+                    <span>{shortcut.description}</span>
+                    {renderHotkey(shortcut.hotkey)}
+                  </li>
+                ))}
+              </ul>
+            </div>
           ))}
-        </ul>
+        </div>
       </div>
     </div>
   )

--- a/apps/web/src/components/fight-page-keyboard-shortcuts-overlay.tsx
+++ b/apps/web/src/components/fight-page-keyboard-shortcuts-overlay.tsx
@@ -70,6 +70,14 @@ function formatHotkeyPart(part: string): string {
     return '/'
   }
 
+  if (normalized === 'period') {
+    return '>'
+  }
+
+  if (normalized === 'comma') {
+    return '<'
+  }
+
   if (normalized.length === 1) {
     return normalized.toUpperCase()
   }

--- a/apps/web/src/components/playback-controls.tsx
+++ b/apps/web/src/components/playback-controls.tsx
@@ -1,0 +1,192 @@
+/**
+ * Playback controls for replay mode: play/pause, speed, and mode toggle.
+ */
+import { Pause, Play, X } from 'lucide-react'
+import type { FC } from 'react'
+
+import { Button } from './ui/button'
+import { Kbd } from './ui/kbd'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './ui/tooltip'
+
+export type PlaybackControlsProps = {
+  isPlaying: boolean
+  isReplayMode: boolean
+  playbackSpeed: number
+  hasPlayhead: boolean
+  onTogglePlayPause: () => void
+  onIncreaseSpeed: () => void
+  onDecreaseSpeed: () => void
+  onToggleReplayMode: () => void
+  onClearPlayhead: () => void
+}
+
+/** Inline playback controls rendered alongside chart controls. */
+export const PlaybackControls: FC<PlaybackControlsProps> = ({
+  isPlaying,
+  isReplayMode,
+  playbackSpeed,
+  hasPlayhead,
+  onTogglePlayPause,
+  onIncreaseSpeed,
+  onDecreaseSpeed,
+  onToggleReplayMode,
+  onClearPlayhead,
+}) => {
+  if (!isReplayMode && !hasPlayhead) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="sm"
+              type="button"
+              variant="outline"
+              onClick={onToggleReplayMode}
+            >
+              Replay
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Enter replay mode <Kbd>R</Kbd>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+  }
+
+  if (!isReplayMode && hasPlayhead) {
+    return (
+      <TooltipProvider>
+        <div className="flex items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="sm"
+                type="button"
+                variant="outline"
+                onClick={onToggleReplayMode}
+              >
+                Resume Replay
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Re-enter replay mode <Kbd>R</Kbd>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+                onClick={onClearPlayhead}
+              >
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Clear playhead</TooltipContent>
+          </Tooltip>
+        </div>
+      </TooltipProvider>
+    )
+  }
+
+  return (
+    <TooltipProvider>
+      <div className="flex items-center gap-1">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="icon-sm"
+              type="button"
+              variant="outline"
+              onClick={onTogglePlayPause}
+            >
+              {isPlaying ? (
+                <Pause className="h-3.5 w-3.5" />
+              ) : (
+                <Play className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {isPlaying ? 'Pause' : 'Play'} <Kbd>Space</Kbd>
+          </TooltipContent>
+        </Tooltip>
+
+        <div className="flex items-center gap-0.5">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+                onClick={onDecreaseSpeed}
+              >
+                <span className="text-[10px] font-medium">&lt;</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Slower <Kbd>&lt;</Kbd>
+            </TooltipContent>
+          </Tooltip>
+
+          <span className="min-w-8 text-center text-xs font-medium tabular-nums text-muted-foreground">
+            {playbackSpeed}x
+          </span>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+                onClick={onIncreaseSpeed}
+              >
+                <span className="text-[10px] font-medium">&gt;</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Faster <Kbd>&gt;</Kbd>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="sm"
+              type="button"
+              variant="outline"
+              onClick={onToggleReplayMode}
+            >
+              Exit Replay
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Exit replay mode <Kbd>R</Kbd> or <Kbd>Esc</Kbd>
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="icon-sm"
+              type="button"
+              variant="ghost"
+              onClick={onClearPlayhead}
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Clear playhead</TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/apps/web/src/components/threat-chart.tsx
+++ b/apps/web/src/components/threat-chart.tsx
@@ -9,6 +9,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 
 import { useThreatChartLegendState } from '../hooks/use-threat-chart-legend-state'
 import { useThreatChartPlayerSearch } from '../hooks/use-threat-chart-player-search'
+import { useThreatChartPlayhead } from '../hooks/use-threat-chart-playhead'
 import { useThreatChartSelectedWindow } from '../hooks/use-threat-chart-selected-window'
 import { useThreatChartSeriesClickHandler } from '../hooks/use-threat-chart-series-click-handler'
 import { useThreatChartSeriesData } from '../hooks/use-threat-chart-series-data'
@@ -19,7 +20,10 @@ import { formatTimelineTime } from '../lib/format'
 import { resolveSeriesWindowBounds } from '../lib/threat-aggregation'
 import { resolvePointSize } from '../lib/threat-chart-point-size'
 import { createThreatChartTooltipFormatter } from '../lib/threat-chart-tooltip'
-import { deathMarkerColor } from '../lib/threat-chart-tooltip-colors'
+import {
+  deathMarkerColor,
+  playheadColor,
+} from '../lib/threat-chart-tooltip-colors'
 import type { SeriesChartPoint } from '../lib/threat-chart-types'
 import { buildAuraMarkArea } from '../lib/threat-chart-visuals'
 import type { BossDamageMode, ThreatSeries } from '../types/app'
@@ -51,6 +55,10 @@ export type ThreatChartProps = {
   targetDeathTimeMs?: number | null
   onChartReadyChange?: (isReady: boolean) => void
   onRegisterResetZoom?: (resetZoom: (() => void) | null) => void
+  isReplayMode?: boolean
+  playheadMs?: number | null
+  onPlayheadChange?: (timeMs: number) => void
+  rightPanel?: React.ReactNode
 }
 
 export const ThreatChart: FC<ThreatChartProps> = ({
@@ -78,6 +86,10 @@ export const ThreatChart: FC<ThreatChartProps> = ({
   targetDeathTimeMs = null,
   onChartReadyChange,
   onRegisterResetZoom,
+  isReplayMode = false,
+  playheadMs = null,
+  onPlayheadChange,
+  rightPanel,
 }) => {
   const chartRef = useRef<ReactEChartsCore>(null)
   const [isChartReady, setIsChartReady] = useState(false)
@@ -105,11 +117,20 @@ export const ThreatChart: FC<ThreatChartProps> = ({
     bounds,
     borderColor: themeColors.border,
     chartRef,
+    enabled: !isReplayMode,
     isChartReady,
     onWindowChange,
     renderer,
     selectedWindow,
     zoomToggleContextKey,
+  })
+
+  useThreatChartPlayhead({
+    chartRef,
+    isChartReady,
+    enabled: isReplayMode,
+    bounds,
+    onPlayheadChange: onPlayheadChange ?? (() => {}),
   })
 
   const { actorIdByLabel, chartSeries, threatStateVisualMaps } =
@@ -367,6 +388,7 @@ export const ThreatChart: FC<ThreatChartProps> = ({
           borderColor: item.color,
         },
         emphasis: {
+          disabled: isReplayMode,
           focus: 'series',
           scale: true,
           itemStyle: {
@@ -387,27 +409,52 @@ export const ThreatChart: FC<ThreatChartProps> = ({
             : [],
           invulnerabilityWindows: [],
         }),
-        ...(seriesIndex === 0 && targetDeathTimeMs !== null
-          ? {
-              markLine: {
-                silent: true,
-                symbol: ['none', 'none'],
-                lineStyle: {
-                  color: deathMarkerColor,
-                  type: 'solid',
-                  width: 2,
-                },
-                label: {
-                  formatter: 'Target death',
-                  color: deathMarkerColor,
-                },
-                data: [{ xAxis: targetDeathTimeMs }],
-              },
-            }
+        ...(seriesIndex === 0
+          ? (() => {
+              const markLineData: Record<string, unknown>[] = []
+              if (targetDeathTimeMs !== null) {
+                markLineData.push({
+                  xAxis: targetDeathTimeMs,
+                  lineStyle: {
+                    color: deathMarkerColor,
+                    type: 'solid' as const,
+                    width: 2,
+                  },
+                  label: {
+                    formatter: 'Target death',
+                    color: deathMarkerColor,
+                  },
+                })
+              }
+              if (playheadMs !== null) {
+                markLineData.push({
+                  xAxis: playheadMs,
+                  lineStyle: {
+                    color: playheadColor,
+                    type: 'solid' as const,
+                    width: 2,
+                  },
+                  label: {
+                    formatter: formatTimelineTime(playheadMs),
+                    color: playheadColor,
+                    position: 'start',
+                  },
+                })
+              }
+              return markLineData.length > 0
+                ? {
+                    markLine: {
+                      silent: true,
+                      symbol: ['none', 'none'],
+                      data: markLineData,
+                    },
+                  }
+                : {}
+            })()
           : {}),
         data: item.data,
       }
-    }),
+    }) as EChartsOption['series'],
   }
 
   return (
@@ -445,18 +492,20 @@ export const ThreatChart: FC<ThreatChartProps> = ({
             }}
           />
         </div>
-        <ThreatChartLegend
-          series={series}
-          isActorVisible={isActorVisible}
-          onActorClick={handleLegendItemClick}
-          onActorFocus={onSeriesClick}
-          pinnedPlayerIds={pinnedPlayerIds}
-          onTogglePinnedPlayer={onTogglePinnedPlayer}
-          showClearSelections={canClearIsolate}
-          onClearSelections={handleClearSelections}
-          showPets={showPets}
-          onShowPetsChange={onShowPetsChange}
-        />
+        {rightPanel ?? (
+          <ThreatChartLegend
+            series={series}
+            isActorVisible={isActorVisible}
+            onActorClick={handleLegendItemClick}
+            onActorFocus={onSeriesClick}
+            pinnedPlayerIds={pinnedPlayerIds}
+            onTogglePinnedPlayer={onTogglePinnedPlayer}
+            showClearSelections={canClearIsolate}
+            onClearSelections={handleClearSelections}
+            showPets={showPets}
+            onShowPetsChange={onShowPetsChange}
+          />
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/components/threat-meter.test.tsx
+++ b/apps/web/src/components/threat-meter.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the ThreatMeter component.
+ */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ThreatAtTimeEntry } from '../lib/threat-at-time'
+import { ThreatMeter } from './threat-meter'
+
+function makeEntry(
+  overrides: Partial<ThreatAtTimeEntry> & { actorId: number },
+): ThreatAtTimeEntry {
+  return {
+    actorName: `Player ${overrides.actorId}`,
+    actorClass: 'Warrior',
+    actorType: 'Player',
+    color: '#C79C6E',
+    threat: 1000,
+    ...overrides,
+  }
+}
+
+describe('ThreatMeter', () => {
+  it('renders sorted entries by threat descending', () => {
+    const entries = [
+      makeEntry({ actorId: 1, actorName: 'Low', threat: 100 }),
+      makeEntry({ actorId: 2, actorName: 'High', threat: 500 }),
+      makeEntry({ actorId: 3, actorName: 'Mid', threat: 300 }),
+    ]
+
+    render(
+      <ThreatMeter
+        entries={entries}
+        focusedActorId={null}
+        selectedPlayerIds={[]}
+        playheadMs={5000}
+        isExpanded={false}
+        onExpandedChange={() => {}}
+      />,
+    )
+
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(3)
+    expect(items[0]).toHaveTextContent('High')
+    expect(items[1]).toHaveTextContent('Mid')
+    expect(items[2]).toHaveTextContent('Low')
+  })
+
+  it('filters out zero-threat entries', () => {
+    const entries = [
+      makeEntry({ actorId: 1, actorName: 'Active', threat: 500 }),
+      makeEntry({ actorId: 2, actorName: 'Idle', threat: 0 }),
+    ]
+
+    render(
+      <ThreatMeter
+        entries={entries}
+        focusedActorId={null}
+        selectedPlayerIds={[]}
+        playheadMs={5000}
+        isExpanded={false}
+        onExpandedChange={() => {}}
+      />,
+    )
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(1)
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
+
+  it('shows expand button when more than 10 entries', () => {
+    const entries = Array.from({ length: 15 }, (_, i) =>
+      makeEntry({ actorId: i + 1, threat: 1000 - i * 10 }),
+    )
+
+    render(
+      <ThreatMeter
+        entries={entries}
+        focusedActorId={null}
+        selectedPlayerIds={[]}
+        playheadMs={5000}
+        isExpanded={false}
+        onExpandedChange={() => {}}
+      />,
+    )
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(10)
+    expect(screen.getByText(/Show all \(15\)/)).toBeInTheDocument()
+  })
+
+  it('shows all entries when expanded', () => {
+    const entries = Array.from({ length: 15 }, (_, i) =>
+      makeEntry({ actorId: i + 1, threat: 1000 - i * 10 }),
+    )
+
+    render(
+      <ThreatMeter
+        entries={entries}
+        focusedActorId={null}
+        selectedPlayerIds={[]}
+        playheadMs={5000}
+        isExpanded={true}
+        onExpandedChange={() => {}}
+      />,
+    )
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(15)
+    expect(screen.getByText(/Show top 10/)).toBeInTheDocument()
+  })
+
+  it('calls onExpandedChange when clicking expand button', async () => {
+    const onExpandedChange = vi.fn()
+    const entries = Array.from({ length: 15 }, (_, i) =>
+      makeEntry({ actorId: i + 1, threat: 1000 - i * 10 }),
+    )
+
+    render(
+      <ThreatMeter
+        entries={entries}
+        focusedActorId={null}
+        selectedPlayerIds={[]}
+        playheadMs={5000}
+        isExpanded={false}
+        onExpandedChange={onExpandedChange}
+      />,
+    )
+
+    await userEvent.click(screen.getByText(/Show all/))
+    expect(onExpandedChange).toHaveBeenCalledWith(true)
+  })
+
+  it('shows empty state when no threat', () => {
+    render(
+      <ThreatMeter
+        entries={[makeEntry({ actorId: 1, threat: 0 })]}
+        focusedActorId={null}
+        selectedPlayerIds={[]}
+        playheadMs={0}
+        isExpanded={false}
+        onExpandedChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('No threat at this time.')).toBeInTheDocument()
+  })
+
+  it('de-emphasizes filtered-out players', () => {
+    const entries = [
+      makeEntry({ actorId: 1, actorName: 'Selected', threat: 500 }),
+      makeEntry({ actorId: 2, actorName: 'Filtered', threat: 300 }),
+    ]
+
+    render(
+      <ThreatMeter
+        entries={entries}
+        focusedActorId={null}
+        selectedPlayerIds={[1]}
+        playheadMs={5000}
+        isExpanded={false}
+        onExpandedChange={() => {}}
+      />,
+    )
+
+    const items = screen.getAllByRole('listitem')
+    expect(items[0]).not.toHaveClass('opacity-40')
+    expect(items[1]).toHaveClass('opacity-40')
+  })
+})

--- a/apps/web/src/components/threat-meter.tsx
+++ b/apps/web/src/components/threat-meter.tsx
@@ -12,6 +12,49 @@ import { ScrollArea } from './ui/scroll-area'
 
 const DEFAULT_VISIBLE_COUNT = 10
 
+type ThreatMeterBarProps = {
+  actorName: string
+  color: string
+  threat: number
+  widthPercent: number
+  isFocused: boolean
+  isFiltered: boolean
+}
+
+/** Single horizontal bar in the threat meter ranking. */
+const ThreatMeterBar: FC<ThreatMeterBarProps> = ({
+  actorName,
+  color,
+  threat,
+  widthPercent,
+  isFocused,
+  isFiltered,
+}) => (
+  <li
+    className={`relative flex h-5 items-center rounded-sm ${isFiltered ? 'opacity-40' : ''}`}
+    style={isFocused ? { boxShadow: 'inset 0 0 0 1px #facc15' } : undefined}
+  >
+    <div
+      className="absolute inset-y-0 left-0 rounded-sm"
+      style={{
+        width: `${widthPercent}%`,
+        backgroundColor: color,
+        opacity: 0.35,
+      }}
+    />
+    <span
+      className="relative z-10 truncate pl-1 text-[10px] font-medium leading-none"
+      style={{ color }}
+      title={actorName}
+    >
+      {actorName}
+    </span>
+    <span className="relative z-10 ml-auto shrink-0 pr-1 text-right text-[10px] text-muted-foreground tabular-nums leading-none">
+      {formatNumber(threat)}
+    </span>
+  </li>
+)
+
 export type ThreatMeterProps = {
   entries: ThreatAtTimeEntry[]
   focusedActorId: number | null
@@ -66,31 +109,15 @@ export const ThreatMeter: FC<ThreatMeterProps> = ({
                 maxThreat > 0 ? (entry.threat / maxThreat) * 100 : 0
 
               return (
-                <li
+                <ThreatMeterBar
                   key={entry.actorId}
-                  className={`flex items-center gap-1.5 rounded px-1 py-0.5 ${isFiltered ? 'opacity-40' : ''}`}
-                >
-                  <span
-                    className="w-16 shrink-0 truncate text-[10px] font-medium"
-                    style={{ color: entry.color }}
-                    title={entry.actorName}
-                  >
-                    {entry.actorName}
-                  </span>
-                  <div className="relative flex-1 h-3.5">
-                    <div
-                      className={`absolute inset-y-0 left-0 rounded-sm ${isFocused ? 'ring-2 ring-yellow-400' : ''}`}
-                      style={{
-                        width: `${widthPercent}%`,
-                        backgroundColor: entry.color,
-                        opacity: 0.7,
-                      }}
-                    />
-                  </div>
-                  <span className="w-12 shrink-0 text-right text-[10px] text-muted-foreground tabular-nums">
-                    {formatNumber(entry.threat)}
-                  </span>
-                </li>
+                  actorName={entry.actorName}
+                  color={entry.color}
+                  threat={entry.threat}
+                  widthPercent={widthPercent}
+                  isFocused={isFocused}
+                  isFiltered={isFiltered}
+                />
               )
             })}
           </ul>

--- a/apps/web/src/components/threat-meter.tsx
+++ b/apps/web/src/components/threat-meter.tsx
@@ -1,0 +1,128 @@
+/**
+ * Ranked threat bar chart shown in the right panel during replay mode.
+ */
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import type { FC } from 'react'
+
+import { formatNumber, formatTimelineTime } from '../lib/format'
+import type { ThreatAtTimeEntry } from '../lib/threat-at-time'
+import { Button } from './ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import { ScrollArea } from './ui/scroll-area'
+
+const DEFAULT_VISIBLE_COUNT = 10
+
+export type ThreatMeterProps = {
+  entries: ThreatAtTimeEntry[]
+  focusedActorId: number | null
+  selectedPlayerIds: number[]
+  playheadMs: number
+  isExpanded: boolean
+  onExpandedChange: (expanded: boolean) => void
+}
+
+/** Ranked horizontal bar chart of threat values at the current playhead timestamp. */
+export const ThreatMeter: FC<ThreatMeterProps> = ({
+  entries,
+  focusedActorId,
+  selectedPlayerIds,
+  playheadMs,
+  isExpanded,
+  onExpandedChange,
+}) => {
+  const sorted = entries
+    .filter((entry) => entry.threat > 0)
+    .sort((a, b) => b.threat - a.threat)
+
+  const maxThreat = sorted[0]?.threat ?? 0
+  const hasFilters = selectedPlayerIds.length > 0
+  const visibleEntries = isExpanded
+    ? sorted
+    : sorted.slice(0, DEFAULT_VISIBLE_COUNT)
+  const hasMore = sorted.length > DEFAULT_VISIBLE_COUNT
+
+  return (
+    <Card
+      className="min-h-0 max-h-[560px] bg-panel"
+      data-size="sm"
+      data-testid="threat-meter"
+    >
+      <CardHeader>
+        <CardTitle className="text-xs">
+          Threat Meter
+          <span className="ml-2 text-muted-foreground font-normal">
+            {formatTimelineTime(playheadMs)}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-col gap-1 px-2 pb-2">
+        <ScrollArea className="min-h-0 flex-1">
+          <ul className="space-y-0.5" role="list">
+            {visibleEntries.map((entry) => {
+              const isFocused = entry.actorId === focusedActorId
+              const isFiltered =
+                hasFilters && !selectedPlayerIds.includes(entry.actorId)
+              const widthPercent =
+                maxThreat > 0 ? (entry.threat / maxThreat) * 100 : 0
+
+              return (
+                <li
+                  key={entry.actorId}
+                  className={`flex items-center gap-1.5 rounded px-1 py-0.5 ${isFiltered ? 'opacity-40' : ''}`}
+                >
+                  <span
+                    className="w-16 shrink-0 truncate text-[10px] font-medium"
+                    style={{ color: entry.color }}
+                    title={entry.actorName}
+                  >
+                    {entry.actorName}
+                  </span>
+                  <div className="relative flex-1 h-3.5">
+                    <div
+                      className={`absolute inset-y-0 left-0 rounded-sm ${isFocused ? 'ring-2 ring-yellow-400' : ''}`}
+                      style={{
+                        width: `${widthPercent}%`,
+                        backgroundColor: entry.color,
+                        opacity: 0.7,
+                      }}
+                    />
+                  </div>
+                  <span className="w-12 shrink-0 text-right text-[10px] text-muted-foreground tabular-nums">
+                    {formatNumber(entry.threat)}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+          {sorted.length === 0 ? (
+            <p className="px-1 py-2 text-[10px] text-muted-foreground">
+              No threat at this time.
+            </p>
+          ) : null}
+        </ScrollArea>
+        {hasMore ? (
+          <Button
+            variant="ghost"
+            size="xs"
+            className="w-full text-[10px]"
+            onClick={() => {
+              onExpandedChange(!isExpanded)
+            }}
+          >
+            {isExpanded ? (
+              <>
+                <ChevronUp className="mr-1 h-3 w-3" />
+                Show top {DEFAULT_VISIBLE_COUNT}
+              </>
+            ) : (
+              <>
+                <ChevronDown className="mr-1 h-3 w-3" />
+                Show all ({sorted.length})
+              </>
+            )}
+          </Button>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/hooks/use-fight-query-state.ts
+++ b/apps/web/src/hooks/use-fight-query-state.ts
@@ -18,6 +18,7 @@ export interface UseFightQueryStateResult {
   setFocusAndPlayers: (focusId: number | null, players: number[]) => void
   setTarget: (target: FightTarget | null) => void
   setWindow: (startMs: number | null, endMs: number | null) => void
+  setPlayheadMs: (playheadMs: number | null) => void
 }
 
 /** Manage fight query params with parsing + normalization rules. */
@@ -113,6 +114,15 @@ export function useFightQueryState({
     [setSearchParams],
   )
 
+  const setPlayheadMs = useCallback(
+    (playheadMs: number | null): void => {
+      setSearchParams((currentSearchParams) =>
+        applyFightQueryState(currentSearchParams, { playheadMs }),
+      )
+    },
+    [setSearchParams],
+  )
+
   return useMemo(
     () => ({
       state,
@@ -122,10 +132,12 @@ export function useFightQueryState({
       setFocusAndPlayers,
       setTarget,
       setWindow,
+      setPlayheadMs,
     }),
     [
       setFocusAndPlayers,
       setFocusId,
+      setPlayheadMs,
       setPinnedPlayers,
       setPlayers,
       setTarget,

--- a/apps/web/src/hooks/use-fight-query-state.ts
+++ b/apps/web/src/hooks/use-fight-query-state.ts
@@ -19,6 +19,11 @@ export interface UseFightQueryStateResult {
   setTarget: (target: FightTarget | null) => void
   setWindow: (startMs: number | null, endMs: number | null) => void
   setPlayheadMs: (playheadMs: number | null) => void
+  setReplay: (replay: boolean) => void
+  setReplayState: (state: {
+    playheadMs?: number | null
+    replay?: boolean
+  }) => void
 }
 
 /** Manage fight query params with parsing + normalization rules. */
@@ -123,6 +128,24 @@ export function useFightQueryState({
     [setSearchParams],
   )
 
+  const setReplay = useCallback(
+    (replay: boolean): void => {
+      setSearchParams((currentSearchParams) =>
+        applyFightQueryState(currentSearchParams, { replay }),
+      )
+    },
+    [setSearchParams],
+  )
+
+  const setReplayState = useCallback(
+    (replayState: { playheadMs?: number | null; replay?: boolean }): void => {
+      setSearchParams((currentSearchParams) =>
+        applyFightQueryState(currentSearchParams, replayState),
+      )
+    },
+    [setSearchParams],
+  )
+
   return useMemo(
     () => ({
       state,
@@ -133,6 +156,8 @@ export function useFightQueryState({
       setTarget,
       setWindow,
       setPlayheadMs,
+      setReplay,
+      setReplayState,
     }),
     [
       setFocusAndPlayers,
@@ -140,6 +165,8 @@ export function useFightQueryState({
       setPlayheadMs,
       setPinnedPlayers,
       setPlayers,
+      setReplay,
+      setReplayState,
       setTarget,
       setWindow,
       state,

--- a/apps/web/src/hooks/use-replay-mode.test.ts
+++ b/apps/web/src/hooks/use-replay-mode.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Unit tests for the replay mode hook.
+ */
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useReplayMode } from './use-replay-mode'
+
+function createProps(
+  overrides: Partial<Parameters<typeof useReplayMode>[0]> = {},
+): Parameters<typeof useReplayMode>[0] {
+  return {
+    committedPlayheadMs: null,
+    committedReplay: false,
+    onCommitState: vi.fn(),
+    resetZoom: vi.fn(),
+    maxMs: 60000,
+    ...overrides,
+  }
+}
+
+describe('useReplayMode', () => {
+  describe('initial state', () => {
+    it('starts inactive when committedReplay is false', () => {
+      const { result } = renderHook(() => useReplayMode(createProps()))
+
+      expect(result.current.isReplayMode).toBe(false)
+      expect(result.current.effectivePlayheadMs).toBeNull()
+      expect(result.current.isPlaying).toBe(false)
+      expect(result.current.playbackSpeed).toBe(1)
+    })
+
+    it('starts active when committedReplay is true', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(
+          createProps({ committedReplay: true, committedPlayheadMs: 5000 }),
+        ),
+      )
+
+      expect(result.current.isReplayMode).toBe(true)
+      expect(result.current.effectivePlayheadMs).toBe(5000)
+    })
+  })
+
+  describe('enterReplayMode', () => {
+    it('enters replay mode and resets zoom', () => {
+      const resetZoom = vi.fn()
+      const onCommitState = vi.fn()
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ resetZoom, onCommitState })),
+      )
+
+      act(() => {
+        result.current.enterReplayMode()
+      })
+
+      expect(result.current.isReplayMode).toBe(true)
+      expect(result.current.effectivePlayheadMs).toBe(0)
+      expect(resetZoom).toHaveBeenCalled()
+      expect(onCommitState).toHaveBeenCalledWith({ replay: true })
+    })
+
+    it('resumes from committed playhead position', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedPlayheadMs: 15000 })),
+      )
+
+      act(() => {
+        result.current.enterReplayMode()
+      })
+
+      expect(result.current.effectivePlayheadMs).toBe(15000)
+    })
+  })
+
+  describe('exitReplayMode', () => {
+    it('exits replay mode and commits playhead and replay state', () => {
+      const onCommitState = vi.fn()
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true, onCommitState })),
+      )
+
+      act(() => {
+        result.current.setPlayheadMs(8000)
+      })
+
+      act(() => {
+        result.current.exitReplayMode()
+      })
+
+      expect(result.current.isReplayMode).toBe(false)
+      expect(onCommitState).toHaveBeenCalledWith({
+        replay: false,
+        playheadMs: 8000,
+      })
+    })
+  })
+
+  describe('toggleReplayMode', () => {
+    it('enters when not in replay mode', () => {
+      const { result } = renderHook(() => useReplayMode(createProps()))
+
+      act(() => {
+        result.current.toggleReplayMode()
+      })
+
+      expect(result.current.isReplayMode).toBe(true)
+    })
+
+    it('exits when in replay mode', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true })),
+      )
+
+      act(() => {
+        result.current.toggleReplayMode()
+      })
+
+      expect(result.current.isReplayMode).toBe(false)
+    })
+  })
+
+  describe('clearPlayhead', () => {
+    it('clears everything and commits null state', () => {
+      const onCommitState = vi.fn()
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true, onCommitState })),
+      )
+
+      act(() => {
+        result.current.setPlayheadMs(5000)
+      })
+
+      act(() => {
+        result.current.clearPlayhead()
+      })
+
+      expect(result.current.isReplayMode).toBe(false)
+      expect(result.current.effectivePlayheadMs).toBeNull()
+      expect(onCommitState).toHaveBeenCalledWith({
+        replay: false,
+        playheadMs: null,
+      })
+    })
+  })
+
+  describe('setPlayheadMs', () => {
+    it('clamps to valid range', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true, maxMs: 10000 })),
+      )
+
+      act(() => {
+        result.current.setPlayheadMs(50000)
+      })
+
+      expect(result.current.effectivePlayheadMs).toBe(10000)
+
+      act(() => {
+        result.current.setPlayheadMs(-100)
+      })
+
+      expect(result.current.effectivePlayheadMs).toBe(0)
+    })
+  })
+
+  describe('speed controls', () => {
+    it('increases speed through tiers', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true })),
+      )
+
+      expect(result.current.playbackSpeed).toBe(1)
+
+      act(() => {
+        result.current.increaseSpeed()
+      })
+      expect(result.current.playbackSpeed).toBe(1.5)
+
+      act(() => {
+        result.current.increaseSpeed()
+      })
+      expect(result.current.playbackSpeed).toBe(2)
+    })
+
+    it('decreases speed through tiers', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true })),
+      )
+
+      act(() => {
+        result.current.decreaseSpeed()
+      })
+      expect(result.current.playbackSpeed).toBe(0.5)
+
+      act(() => {
+        result.current.decreaseSpeed()
+      })
+      expect(result.current.playbackSpeed).toBe(0.25)
+    })
+
+    it('clamps at min and max speed', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true })),
+      )
+
+      act(() => {
+        result.current.increaseSpeed()
+        result.current.increaseSpeed()
+        result.current.increaseSpeed()
+        result.current.increaseSpeed()
+      })
+      expect(result.current.playbackSpeed).toBe(2)
+
+      act(() => {
+        result.current.decreaseSpeed()
+        result.current.decreaseSpeed()
+        result.current.decreaseSpeed()
+        result.current.decreaseSpeed()
+        result.current.decreaseSpeed()
+        result.current.decreaseSpeed()
+      })
+      expect(result.current.playbackSpeed).toBe(0.25)
+    })
+  })
+
+  describe('stepping', () => {
+    it('steps forward by 1 second', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true })),
+      )
+
+      act(() => {
+        result.current.setPlayheadMs(5000)
+      })
+
+      act(() => {
+        result.current.stepForward()
+      })
+
+      expect(result.current.effectivePlayheadMs).toBe(6000)
+    })
+
+    it('steps forward by 100ms with fineStep', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true })),
+      )
+
+      act(() => {
+        result.current.setPlayheadMs(5000)
+      })
+
+      act(() => {
+        result.current.stepForward(true)
+      })
+
+      expect(result.current.effectivePlayheadMs).toBe(5100)
+    })
+
+    it('steps backward by 1 second', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true })),
+      )
+
+      act(() => {
+        result.current.setPlayheadMs(5000)
+      })
+
+      act(() => {
+        result.current.stepBackward()
+      })
+
+      expect(result.current.effectivePlayheadMs).toBe(4000)
+    })
+
+    it('steps backward by 100ms with fineStep', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true })),
+      )
+
+      act(() => {
+        result.current.setPlayheadMs(5000)
+      })
+
+      act(() => {
+        result.current.stepBackward(true)
+      })
+
+      expect(result.current.effectivePlayheadMs).toBe(4900)
+    })
+
+    it('clamps step forward at maxMs', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true, maxMs: 5500 })),
+      )
+
+      act(() => {
+        result.current.setPlayheadMs(5000)
+      })
+
+      act(() => {
+        result.current.stepForward()
+      })
+
+      expect(result.current.effectivePlayheadMs).toBe(5500)
+    })
+
+    it('clamps step backward at 0', () => {
+      const { result } = renderHook(() =>
+        useReplayMode(createProps({ committedReplay: true })),
+      )
+
+      act(() => {
+        result.current.setPlayheadMs(500)
+      })
+
+      act(() => {
+        result.current.stepBackward()
+      })
+
+      expect(result.current.effectivePlayheadMs).toBe(0)
+    })
+  })
+})

--- a/apps/web/src/hooks/use-replay-mode.ts
+++ b/apps/web/src/hooks/use-replay-mode.ts
@@ -1,0 +1,236 @@
+/**
+ * Central hook for replay mode state, playback animation, and playhead management.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const PLAYBACK_SPEEDS = [0.25, 0.5, 1, 1.5, 2] as const
+const DEFAULT_SPEED_INDEX = 2 // 1x
+
+export interface UseReplayModeResult {
+  isReplayMode: boolean
+  effectivePlayheadMs: number | null
+  isPlaying: boolean
+  playbackSpeed: number
+  enterReplayMode: () => void
+  exitReplayMode: () => void
+  toggleReplayMode: () => void
+  clearPlayhead: () => void
+  setPlayheadMs: (ms: number) => void
+  play: () => void
+  pause: () => void
+  togglePlayPause: () => void
+  increaseSpeed: () => void
+  decreaseSpeed: () => void
+  stepForward: (fineStep?: boolean) => void
+  stepBackward: (fineStep?: boolean) => void
+}
+
+/** Manage replay mode lifecycle, playhead position, and playback animation. */
+export function useReplayMode({
+  committedPlayheadMs,
+  onCommit,
+  resetZoom,
+  maxMs,
+}: {
+  committedPlayheadMs: number | null
+  onCommit: (playheadMs: number | null) => void
+  resetZoom: () => void
+  maxMs: number
+}): UseReplayModeResult {
+  const [isReplayMode, setIsReplayMode] = useState(committedPlayheadMs !== null)
+  const [localPlayheadMs, setLocalPlayheadMs] = useState<number | null>(null)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [speedIndex, setSpeedIndex] = useState(DEFAULT_SPEED_INDEX)
+
+  const rafRef = useRef<number | null>(null)
+  const lastFrameTimeRef = useRef<number | null>(null)
+  const playheadRef = useRef<number>(0)
+  const speedRef = useRef<number>(PLAYBACK_SPEEDS[DEFAULT_SPEED_INDEX]!)
+  const maxMsRef = useRef(maxMs)
+
+  useEffect(() => {
+    maxMsRef.current = maxMs
+  }, [maxMs])
+
+  const playbackSpeed = PLAYBACK_SPEEDS[speedIndex]!
+
+  useEffect(() => {
+    speedRef.current = playbackSpeed
+  }, [playbackSpeed])
+
+  const effectivePlayheadMs = localPlayheadMs ?? committedPlayheadMs
+
+  const stopAnimation = useCallback((): void => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+    lastFrameTimeRef.current = null
+  }, [])
+
+  const commitPlayhead = useCallback(
+    (ms: number | null): void => {
+      onCommit(ms)
+    },
+    [onCommit],
+  )
+
+  const enterReplayMode = useCallback((): void => {
+    resetZoom()
+    setIsReplayMode(true)
+    const startMs = committedPlayheadMs ?? 0
+    setLocalPlayheadMs(startMs)
+    playheadRef.current = startMs
+  }, [committedPlayheadMs, resetZoom])
+
+  const exitReplayMode = useCallback((): void => {
+    stopAnimation()
+    setIsPlaying(false)
+    setIsReplayMode(false)
+    if (localPlayheadMs !== null) {
+      commitPlayhead(localPlayheadMs)
+    }
+    setLocalPlayheadMs(null)
+  }, [commitPlayhead, localPlayheadMs, stopAnimation])
+
+  const toggleReplayMode = useCallback((): void => {
+    if (isReplayMode) {
+      exitReplayMode()
+    } else {
+      enterReplayMode()
+    }
+  }, [enterReplayMode, exitReplayMode, isReplayMode])
+
+  const clearPlayhead = useCallback((): void => {
+    stopAnimation()
+    setIsPlaying(false)
+    setIsReplayMode(false)
+    setLocalPlayheadMs(null)
+    commitPlayhead(null)
+  }, [commitPlayhead, stopAnimation])
+
+  const setPlayheadMs = useCallback((ms: number): void => {
+    const clamped = Math.max(0, Math.min(ms, maxMsRef.current))
+    setLocalPlayheadMs(clamped)
+    playheadRef.current = clamped
+  }, [])
+
+  const play = useCallback((): void => {
+    if (!isReplayMode) {
+      return
+    }
+
+    const startMs = effectivePlayheadMs ?? 0
+    if (startMs >= maxMs) {
+      playheadRef.current = 0
+      setLocalPlayheadMs(0)
+    } else {
+      playheadRef.current = startMs
+    }
+
+    setIsPlaying(true)
+    lastFrameTimeRef.current = null
+
+    const tick = (frameTime: number): void => {
+      if (lastFrameTimeRef.current === null) {
+        lastFrameTimeRef.current = frameTime
+        rafRef.current = requestAnimationFrame(tick)
+        return
+      }
+
+      const deltaMs = (frameTime - lastFrameTimeRef.current) * speedRef.current
+      lastFrameTimeRef.current = frameTime
+
+      const nextMs = Math.min(playheadRef.current + deltaMs, maxMsRef.current)
+      playheadRef.current = nextMs
+      setLocalPlayheadMs(nextMs)
+
+      if (nextMs >= maxMsRef.current) {
+        setIsPlaying(false)
+        lastFrameTimeRef.current = null
+        rafRef.current = null
+        return
+      }
+
+      rafRef.current = requestAnimationFrame(tick)
+    }
+
+    rafRef.current = requestAnimationFrame(tick)
+  }, [effectivePlayheadMs, isReplayMode, maxMs])
+
+  const pause = useCallback((): void => {
+    stopAnimation()
+    setIsPlaying(false)
+    if (localPlayheadMs !== null) {
+      commitPlayhead(localPlayheadMs)
+    }
+  }, [commitPlayhead, localPlayheadMs, stopAnimation])
+
+  const togglePlayPause = useCallback((): void => {
+    if (isPlaying) {
+      pause()
+    } else {
+      play()
+    }
+  }, [isPlaying, pause, play])
+
+  const increaseSpeed = useCallback((): void => {
+    setSpeedIndex((current) =>
+      Math.min(current + 1, PLAYBACK_SPEEDS.length - 1),
+    )
+  }, [])
+
+  const decreaseSpeed = useCallback((): void => {
+    setSpeedIndex((current) => Math.max(current - 1, 0))
+  }, [])
+
+  const stepForward = useCallback(
+    (fineStep = false): void => {
+      const stepMs = fineStep ? 100 : 1000
+      const current = effectivePlayheadMs ?? 0
+      const next = Math.min(current + stepMs, maxMs)
+      setLocalPlayheadMs(next)
+      playheadRef.current = next
+    },
+    [effectivePlayheadMs, maxMs],
+  )
+
+  const stepBackward = useCallback(
+    (fineStep = false): void => {
+      const stepMs = fineStep ? 100 : 1000
+      const current = effectivePlayheadMs ?? 0
+      const next = Math.max(current - stepMs, 0)
+      setLocalPlayheadMs(next)
+      playheadRef.current = next
+    },
+    [effectivePlayheadMs],
+  )
+
+  // Cleanup animation on unmount
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current)
+      }
+    }
+  }, [])
+
+  return {
+    isReplayMode,
+    effectivePlayheadMs,
+    isPlaying,
+    playbackSpeed,
+    enterReplayMode,
+    exitReplayMode,
+    toggleReplayMode,
+    clearPlayhead,
+    setPlayheadMs,
+    play,
+    pause,
+    togglePlayPause,
+    increaseSpeed,
+    decreaseSpeed,
+    stepForward,
+    stepBackward,
+  }
+}

--- a/apps/web/src/hooks/use-replay-mode.ts
+++ b/apps/web/src/hooks/use-replay-mode.ts
@@ -28,16 +28,21 @@ export interface UseReplayModeResult {
 /** Manage replay mode lifecycle, playhead position, and playback animation. */
 export function useReplayMode({
   committedPlayheadMs,
-  onCommit,
+  committedReplay,
+  onCommitState,
   resetZoom,
   maxMs,
 }: {
   committedPlayheadMs: number | null
-  onCommit: (playheadMs: number | null) => void
+  committedReplay: boolean
+  onCommitState: (state: {
+    playheadMs?: number | null
+    replay?: boolean
+  }) => void
   resetZoom: () => void
   maxMs: number
 }): UseReplayModeResult {
-  const [isReplayMode, setIsReplayMode] = useState(committedPlayheadMs !== null)
+  const [isReplayMode, setIsReplayMode] = useState(committedReplay)
   const [localPlayheadMs, setLocalPlayheadMs] = useState<number | null>(null)
   const [isPlaying, setIsPlaying] = useState(false)
   const [speedIndex, setSpeedIndex] = useState(DEFAULT_SPEED_INDEX)
@@ -68,30 +73,25 @@ export function useReplayMode({
     lastFrameTimeRef.current = null
   }, [])
 
-  const commitPlayhead = useCallback(
-    (ms: number | null): void => {
-      onCommit(ms)
-    },
-    [onCommit],
-  )
-
   const enterReplayMode = useCallback((): void => {
     resetZoom()
     setIsReplayMode(true)
+    onCommitState({ replay: true })
     const startMs = committedPlayheadMs ?? 0
     setLocalPlayheadMs(startMs)
     playheadRef.current = startMs
-  }, [committedPlayheadMs, resetZoom])
+  }, [committedPlayheadMs, onCommitState, resetZoom])
 
   const exitReplayMode = useCallback((): void => {
     stopAnimation()
     setIsPlaying(false)
     setIsReplayMode(false)
-    if (localPlayheadMs !== null) {
-      commitPlayhead(localPlayheadMs)
-    }
+    onCommitState({
+      replay: false,
+      playheadMs: localPlayheadMs,
+    })
     setLocalPlayheadMs(null)
-  }, [commitPlayhead, localPlayheadMs, stopAnimation])
+  }, [localPlayheadMs, onCommitState, stopAnimation])
 
   const toggleReplayMode = useCallback((): void => {
     if (isReplayMode) {
@@ -106,8 +106,8 @@ export function useReplayMode({
     setIsPlaying(false)
     setIsReplayMode(false)
     setLocalPlayheadMs(null)
-    commitPlayhead(null)
-  }, [commitPlayhead, stopAnimation])
+    onCommitState({ replay: false, playheadMs: null })
+  }, [onCommitState, stopAnimation])
 
   const setPlayheadMs = useCallback((ms: number): void => {
     const clamped = Math.max(0, Math.min(ms, maxMsRef.current))
@@ -162,9 +162,9 @@ export function useReplayMode({
     stopAnimation()
     setIsPlaying(false)
     if (localPlayheadMs !== null) {
-      commitPlayhead(localPlayheadMs)
+      onCommitState({ playheadMs: localPlayheadMs })
     }
-  }, [commitPlayhead, localPlayheadMs, stopAnimation])
+  }, [localPlayheadMs, onCommitState, stopAnimation])
 
   const togglePlayPause = useCallback((): void => {
     if (isPlaying) {

--- a/apps/web/src/hooks/use-threat-chart-playhead.ts
+++ b/apps/web/src/hooks/use-threat-chart-playhead.ts
@@ -1,0 +1,134 @@
+/**
+ * Click-to-place and drag-to-scrub playhead interaction for replay mode.
+ */
+import type ReactEChartsCore from 'echarts-for-react/esm/core'
+import type { RefObject } from 'react'
+import { useEffect } from 'react'
+
+interface PointerEventLike {
+  offsetX?: number
+  offsetY?: number
+  zrX?: number
+  zrY?: number
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+/** Attach ZRender handlers for click-to-place and drag-to-scrub playhead in replay mode. */
+export function useThreatChartPlayhead({
+  chartRef,
+  isChartReady,
+  enabled,
+  bounds,
+  onPlayheadChange,
+}: {
+  chartRef: RefObject<ReactEChartsCore | null>
+  isChartReady: boolean
+  enabled: boolean
+  bounds: { min: number; max: number }
+  onPlayheadChange: (timeMs: number) => void
+}): void {
+  useEffect(() => {
+    if (!enabled || !isChartReady) {
+      return
+    }
+
+    const chart = chartRef.current?.getEchartsInstance()
+    if (!chart) {
+      return
+    }
+
+    const zr = chart.getZr()
+    let isDragging = false
+
+    const resolvePointer = (
+      event: PointerEventLike,
+    ): [number, number] | null => {
+      const x = event.offsetX ?? event.zrX
+      const y = event.offsetY ?? event.zrY
+      if (
+        x === undefined ||
+        y === undefined ||
+        !Number.isFinite(x) ||
+        !Number.isFinite(y)
+      ) {
+        return null
+      }
+
+      return [x, y]
+    }
+
+    const pixelToTime = (pixelX: number): number | null => {
+      const clampedX = clamp(pixelX, 0, chart.getWidth())
+      const value = Number(chart.convertFromPixel({ xAxisIndex: 0 }, clampedX))
+      if (!Number.isFinite(value)) {
+        return null
+      }
+
+      return clamp(Math.round(value), bounds.min, bounds.max)
+    }
+
+    const handleMouseDown = (event: PointerEventLike): void => {
+      const pointer = resolvePointer(event)
+      if (!pointer) {
+        return
+      }
+
+      const isInGrid = chart.containPixel({ gridIndex: 0 }, pointer)
+      if (!isInGrid) {
+        return
+      }
+
+      isDragging = true
+      const timeMs = pixelToTime(pointer[0])
+      if (timeMs !== null) {
+        onPlayheadChange(timeMs)
+      }
+    }
+
+    const handleMouseMove = (event: PointerEventLike): void => {
+      if (!isDragging) {
+        return
+      }
+
+      const pointer = resolvePointer(event)
+      if (!pointer) {
+        return
+      }
+
+      const timeMs = pixelToTime(pointer[0])
+      if (timeMs !== null) {
+        onPlayheadChange(timeMs)
+      }
+    }
+
+    const handleMouseUp = (): void => {
+      isDragging = false
+    }
+
+    const handleDocumentMouseUp = (): void => {
+      isDragging = false
+    }
+
+    zr.on('mousedown', handleMouseDown)
+    zr.on('mousemove', handleMouseMove)
+    zr.on('mouseup', handleMouseUp)
+    window.addEventListener('mouseup', handleDocumentMouseUp)
+
+    return () => {
+      zr.off('mousedown', handleMouseDown)
+      zr.off('mousemove', handleMouseMove)
+      zr.off('mouseup', handleMouseUp)
+      window.removeEventListener('mouseup', handleDocumentMouseUp)
+    }
+  }, [
+    bounds.max,
+    bounds.min,
+    chartRef,
+    enabled,
+    isChartReady,
+    onPlayheadChange,
+  ])
+}

--- a/apps/web/src/hooks/use-threat-chart-zoom.ts
+++ b/apps/web/src/hooks/use-threat-chart-zoom.ts
@@ -37,6 +37,7 @@ export function useThreatChartZoom({
   bounds,
   borderColor,
   chartRef,
+  enabled = true,
   isChartReady,
   onWindowChange,
   renderer,
@@ -46,6 +47,7 @@ export function useThreatChartZoom({
   bounds: { max: number; min: number }
   borderColor: string
   chartRef: MutableRefObject<ReactEChartsCore | null>
+  enabled?: boolean
   isChartReady: boolean
   onWindowChange: (startMs: number | null, endMs: number | null) => void
   renderer: 'canvas' | 'svg'
@@ -148,7 +150,7 @@ export function useThreatChartZoom({
   }, [activeXAxisWindow, isFullChartZoom, onWindowChange, yAxisWindow])
 
   useEffect(() => {
-    if (!isChartReady) {
+    if (!enabled || !isChartReady) {
       return
     }
 
@@ -371,6 +373,7 @@ export function useThreatChartZoom({
     bounds.max,
     bounds.min,
     chartRef,
+    enabled,
     isChartReady,
     onWindowChange,
     renderer,

--- a/apps/web/src/lib/search-params.test.ts
+++ b/apps/web/src/lib/search-params.test.ts
@@ -73,6 +73,7 @@ describe('search-params', () => {
       targetInstance: 0,
       startMs: 100,
       endMs: 200,
+      playheadMs: null,
     })
   })
 
@@ -98,6 +99,7 @@ describe('search-params', () => {
       targetInstance: null,
       startMs: null,
       endMs: null,
+      playheadMs: null,
     })
   })
 
@@ -121,6 +123,72 @@ describe('search-params', () => {
     expect(next.toString()).toContain('endMs=80')
   })
 
+  it('parses valid playheadMs from query params', () => {
+    const params = new URLSearchParams({ playheadMs: '5000' })
+
+    expect(
+      resolveFightQueryState({
+        searchParams: params,
+        validPlayerIds: new Set(),
+        validActorIds: new Set(),
+        validTargetKeys: new Set(),
+        maxDurationMs: 10000,
+      }),
+    ).toMatchObject({ playheadMs: 5000 })
+  })
+
+  it('rejects playheadMs exceeding fight duration', () => {
+    const params = new URLSearchParams({ playheadMs: '20000' })
+
+    expect(
+      resolveFightQueryState({
+        searchParams: params,
+        validPlayerIds: new Set(),
+        validActorIds: new Set(),
+        validTargetKeys: new Set(),
+        maxDurationMs: 10000,
+      }),
+    ).toMatchObject({ playheadMs: null })
+  })
+
+  it('rejects negative playheadMs', () => {
+    const params = new URLSearchParams({ playheadMs: '-100' })
+
+    expect(
+      resolveFightQueryState({
+        searchParams: params,
+        validPlayerIds: new Set(),
+        validActorIds: new Set(),
+        validTargetKeys: new Set(),
+        maxDurationMs: 10000,
+      }),
+    ).toMatchObject({ playheadMs: null })
+  })
+
+  it('accepts playheadMs of zero', () => {
+    const params = new URLSearchParams({ playheadMs: '0' })
+
+    expect(
+      resolveFightQueryState({
+        searchParams: params,
+        validPlayerIds: new Set(),
+        validActorIds: new Set(),
+        validTargetKeys: new Set(),
+        maxDurationMs: 10000,
+      }),
+    ).toMatchObject({ playheadMs: 0 })
+  })
+
+  it('serializes and deletes playheadMs in applyFightQueryState', () => {
+    const withPlayhead = applyFightQueryState(new URLSearchParams(), {
+      playheadMs: 7500,
+    })
+    expect(withPlayhead.get('playheadMs')).toBe('7500')
+
+    const cleared = applyFightQueryState(withPlayhead, { playheadMs: null })
+    expect(cleared.has('playheadMs')).toBe(false)
+  })
+
   it('keeps players empty when players is missing and pinnedPlayers exists', () => {
     const params = new URLSearchParams({
       pinnedPlayers: '3,1,3',
@@ -142,6 +210,7 @@ describe('search-params', () => {
       targetInstance: null,
       startMs: null,
       endMs: null,
+      playheadMs: null,
     })
   })
 })

--- a/apps/web/src/lib/search-params.test.ts
+++ b/apps/web/src/lib/search-params.test.ts
@@ -74,6 +74,7 @@ describe('search-params', () => {
       startMs: 100,
       endMs: 200,
       playheadMs: null,
+      replay: false,
     })
   })
 
@@ -100,6 +101,7 @@ describe('search-params', () => {
       startMs: null,
       endMs: null,
       playheadMs: null,
+      replay: false,
     })
   })
 
@@ -211,6 +213,7 @@ describe('search-params', () => {
       startMs: null,
       endMs: null,
       playheadMs: null,
+      replay: false,
     })
   })
 })

--- a/apps/web/src/lib/search-params.ts
+++ b/apps/web/src/lib/search-params.ts
@@ -133,6 +133,8 @@ export function resolveFightQueryState({
       ? parsedPlayheadMs
       : null
 
+  const replay = searchParams.get('replay') === '1'
+
   return {
     players,
     pinnedPlayers,
@@ -142,6 +144,7 @@ export function resolveFightQueryState({
     startMs,
     endMs,
     playheadMs,
+    replay,
   }
 }
 
@@ -218,6 +221,14 @@ export function applyFightQueryState(
       next.delete('playheadMs')
     } else {
       next.set('playheadMs', String(state.playheadMs))
+    }
+  }
+
+  if (state.replay !== undefined) {
+    if (state.replay) {
+      next.set('replay', '1')
+    } else {
+      next.set('replay', '0')
     }
   }
 

--- a/apps/web/src/lib/search-params.ts
+++ b/apps/web/src/lib/search-params.ts
@@ -125,6 +125,14 @@ export function resolveFightQueryState({
     maxDurationMs,
   )
 
+  const parsedPlayheadMs = parseInteger(searchParams.get('playheadMs'))
+  const playheadMs =
+    parsedPlayheadMs !== null &&
+    parsedPlayheadMs >= 0 &&
+    parsedPlayheadMs <= maxDurationMs
+      ? parsedPlayheadMs
+      : null
+
   return {
     players,
     pinnedPlayers,
@@ -133,6 +141,7 @@ export function resolveFightQueryState({
     targetInstance: parsedTargetSelection?.targetInstance ?? null,
     startMs,
     endMs,
+    playheadMs,
   }
 }
 
@@ -201,6 +210,14 @@ export function applyFightQueryState(
     } else {
       next.set('startMs', String(state.startMs))
       next.set('endMs', String(state.endMs))
+    }
+  }
+
+  if (state.playheadMs !== undefined) {
+    if (state.playheadMs === null) {
+      next.delete('playheadMs')
+    } else {
+      next.set('playheadMs', String(state.playheadMs))
     }
   }
 

--- a/apps/web/src/lib/threat-at-time.test.ts
+++ b/apps/web/src/lib/threat-at-time.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for threat-at-time binary search utility.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { ThreatPoint, ThreatSeries } from '../types/app'
+import { findLastPointAtOrBefore, getThreatAtTime } from './threat-at-time'
+
+function makePoint(timeMs: number, totalThreat: number): ThreatPoint {
+  return {
+    timestamp: timeMs,
+    timeMs,
+    totalThreat,
+    threatDelta: 0,
+    amount: 0,
+    baseThreat: 0,
+    modifiedThreat: 0,
+    eventType: 'damage',
+    abilityName: 'Test',
+    spellSchool: null,
+    modifiers: [],
+  }
+}
+
+function makeSeries(
+  overrides: Partial<ThreatSeries> & { points: ThreatPoint[] },
+): ThreatSeries {
+  return {
+    actorId: 1,
+    actorName: 'Player',
+    actorClass: 'Warrior',
+    actorType: 'Player',
+    actorRole: undefined,
+    ownerId: null,
+    label: 'Player',
+    color: '#C79C6E',
+    maxThreat: 0,
+    totalThreat: 0,
+    totalDamage: 0,
+    totalHealing: 0,
+    stateVisualSegments: [],
+    fixateWindows: [],
+    invulnerabilityWindows: [],
+    ...overrides,
+  }
+}
+
+describe('findLastPointAtOrBefore', () => {
+  it('returns null for empty points', () => {
+    expect(findLastPointAtOrBefore([], 1000)).toBeNull()
+  })
+
+  it('returns null when timeMs is before the first point', () => {
+    const points = [makePoint(500, 100)]
+    expect(findLastPointAtOrBefore(points, 200)).toBeNull()
+  })
+
+  it('returns exact match', () => {
+    const points = [
+      makePoint(100, 50),
+      makePoint(200, 100),
+      makePoint(300, 150),
+    ]
+    expect(findLastPointAtOrBefore(points, 200)?.totalThreat).toBe(100)
+  })
+
+  it('returns the last point at or before timeMs (step-end)', () => {
+    const points = [
+      makePoint(100, 50),
+      makePoint(300, 150),
+      makePoint(500, 250),
+    ]
+    expect(findLastPointAtOrBefore(points, 200)?.totalThreat).toBe(50)
+    expect(findLastPointAtOrBefore(points, 400)?.totalThreat).toBe(150)
+  })
+
+  it('returns last point when timeMs is after all points', () => {
+    const points = [makePoint(100, 50), makePoint(200, 100)]
+    expect(findLastPointAtOrBefore(points, 9999)?.totalThreat).toBe(100)
+  })
+
+  it('returns first point when timeMs matches first point exactly', () => {
+    const points = [makePoint(0, 10), makePoint(100, 20)]
+    expect(findLastPointAtOrBefore(points, 0)?.totalThreat).toBe(10)
+  })
+
+  it('handles single-element array', () => {
+    const points = [makePoint(100, 50)]
+    expect(findLastPointAtOrBefore(points, 100)?.totalThreat).toBe(50)
+    expect(findLastPointAtOrBefore(points, 200)?.totalThreat).toBe(50)
+    expect(findLastPointAtOrBefore(points, 50)).toBeNull()
+  })
+})
+
+describe('getThreatAtTime', () => {
+  it('returns threat for multiple series at a given time', () => {
+    const series = [
+      makeSeries({
+        actorId: 1,
+        actorName: 'Warrior',
+        points: [makePoint(0, 0), makePoint(100, 500), makePoint(200, 1000)],
+      }),
+      makeSeries({
+        actorId: 2,
+        actorName: 'Rogue',
+        actorClass: 'Rogue',
+        color: '#FFF569',
+        points: [makePoint(50, 0), makePoint(150, 300)],
+      }),
+    ]
+
+    const result = getThreatAtTime(series, 150)
+    expect(result).toEqual([
+      expect.objectContaining({
+        actorId: 1,
+        actorName: 'Warrior',
+        threat: 500,
+      }),
+      expect.objectContaining({ actorId: 2, actorName: 'Rogue', threat: 300 }),
+    ])
+  })
+
+  it('returns zero threat for series with no points before timeMs', () => {
+    const series = [
+      makeSeries({
+        actorId: 1,
+        points: [makePoint(500, 100)],
+      }),
+    ]
+
+    const result = getThreatAtTime(series, 100)
+    expect(result[0]?.threat).toBe(0)
+  })
+
+  it('returns zero threat for series with empty points', () => {
+    const series = [makeSeries({ actorId: 1, points: [] })]
+
+    const result = getThreatAtTime(series, 100)
+    expect(result[0]?.threat).toBe(0)
+  })
+})

--- a/apps/web/src/lib/threat-at-time.ts
+++ b/apps/web/src/lib/threat-at-time.ts
@@ -1,0 +1,65 @@
+/**
+ * Binary search utilities for resolving cumulative threat at a given timestamp.
+ */
+import type { PlayerClass } from '@wow-threat/wcl-types'
+
+import type { ThreatPoint, ThreatSeries } from '../types/app'
+
+export interface ThreatAtTimeEntry {
+  actorId: number
+  actorName: string
+  actorClass: PlayerClass | null
+  actorType: 'Player' | 'Pet'
+  color: string
+  threat: number
+}
+
+/** Find the last ThreatPoint at or before timeMs using binary search (step-end interpolation). */
+export function findLastPointAtOrBefore(
+  points: ThreatPoint[],
+  timeMs: number,
+): ThreatPoint | null {
+  if (points.length === 0) {
+    return null
+  }
+
+  let low = 0
+  let high = points.length - 1
+
+  if (points[low]!.timeMs > timeMs) {
+    return null
+  }
+
+  if (points[high]!.timeMs <= timeMs) {
+    return points[high]!
+  }
+
+  while (low < high) {
+    const mid = low + Math.floor((high - low + 1) / 2)
+    if (points[mid]!.timeMs <= timeMs) {
+      low = mid
+    } else {
+      high = mid - 1
+    }
+  }
+
+  return points[low]!
+}
+
+/** Resolve cumulative threat for all actors at a given timestamp. */
+export function getThreatAtTime(
+  series: ThreatSeries[],
+  timeMs: number,
+): ThreatAtTimeEntry[] {
+  return series.map((s) => {
+    const point = findLastPointAtOrBefore(s.points, timeMs)
+    return {
+      actorId: s.actorId,
+      actorName: s.actorName,
+      actorClass: s.actorClass,
+      actorType: s.actorType,
+      color: s.color,
+      threat: point?.totalThreat ?? 0,
+    }
+  })
+}

--- a/apps/web/src/lib/threat-chart-tooltip-colors.ts
+++ b/apps/web/src/lib/threat-chart-tooltip-colors.ts
@@ -4,3 +4,4 @@
 export const bossMeleeMarkerColor = '#ef4444'
 export const deathMarkerColor = '#dc2626'
 export const tranquilAirTotemMarkerColor = '#3b82f6'
+export const playheadColor = '#facc15'

--- a/apps/web/src/pages/fight-page.spec.ts
+++ b/apps/web/src/pages/fight-page.spec.ts
@@ -570,4 +570,92 @@ test.describe('fight page', () => {
     await expect(fightPage.chart.resetZoomButton()).toBeEnabled()
     await expect(page.getByTestId('fight-chart-skeleton')).toHaveCount(0)
   })
+
+  test('enters and exits replay mode via R key', async ({ page }) => {
+    const fightPage = new FightPageObject(page)
+
+    await fightPage.goto(svgFightUrl)
+    await expect.poll(() => fightPage.chart.renderer()).toBe('svg')
+
+    // Replay button visible before entering
+    await expect(fightPage.replay.replayButton()).toBeVisible()
+    await expect(fightPage.replay.threatMeter()).toHaveCount(0)
+
+    // Enter replay mode
+    await fightPage.replay.enterWithKey()
+    await expect(fightPage.replay.threatMeter()).toBeVisible()
+    await expect(fightPage.replay.exitReplayButton()).toBeVisible()
+    await expect(fightPage.replay.replayButton()).toHaveCount(0)
+    await expectSearchParam(page, 'replay', '1')
+
+    // Exit replay mode with R
+    await fightPage.replay.exitWithKey()
+    await expect(fightPage.replay.threatMeter()).toHaveCount(0)
+    await expect(fightPage.chart.legendRoot()).toBeVisible()
+    await expectSearchParam(page, 'replay', '0')
+    // Playhead persists in URL after exit
+    await expectSearchParam(page, 'playheadMs', '0')
+  })
+
+  test('exits replay mode via Escape key', async ({ page }) => {
+    const fightPage = new FightPageObject(page)
+
+    await fightPage.goto(svgFightUrl)
+    await expect.poll(() => fightPage.chart.renderer()).toBe('svg')
+
+    await fightPage.replay.enterWithKey()
+    await expect(fightPage.replay.threatMeter()).toBeVisible()
+
+    await fightPage.replay.exitWithEscape()
+    await expect(fightPage.replay.threatMeter()).toHaveCount(0)
+    await expect(fightPage.chart.legendRoot()).toBeVisible()
+    await expectSearchParam(page, 'replay', '0')
+  })
+
+  test('deep-links into replay mode with playheadMs and replay params', async ({
+    page,
+  }) => {
+    const fightPage = new FightPageObject(page)
+
+    await fightPage.goto(`${svgFightUrl}&playheadMs=5000&replay=1`)
+    await expect.poll(() => fightPage.chart.renderer()).toBe('svg')
+
+    await expect(fightPage.replay.threatMeter()).toBeVisible()
+    await expect(fightPage.replay.exitReplayButton()).toBeVisible()
+  })
+
+  test('shows replay shortcuts in grouped section of shortcuts overlay', async ({
+    page,
+  }) => {
+    const fightPage = new FightPageObject(page)
+
+    await fightPage.goto(svgFightUrl)
+    await expect.poll(() => fightPage.chart.renderer()).toBe('svg')
+
+    await fightPage.shortcuts.open()
+    await expect(fightPage.shortcuts.dialog()).toBeVisible()
+
+    // Verify group headings
+    await expect(fightPage.shortcuts.groupHeading('Chart')).toBeVisible()
+    await expect(fightPage.shortcuts.groupHeading('Replay')).toBeVisible()
+
+    // Verify replay shortcuts
+    await expect(
+      fightPage.shortcuts.shortcutListItem('Toggle replay mode'),
+    ).toBeVisible()
+    await expect(
+      fightPage.shortcuts.shortcutKey('Toggle replay mode', 'R'),
+    ).toBeVisible()
+    await expect(
+      fightPage.shortcuts.shortcutListItem('Play / Pause'),
+    ).toBeVisible()
+    await expect(
+      fightPage.shortcuts.shortcutListItem('Increase playback speed'),
+    ).toBeVisible()
+    await expect(
+      fightPage.shortcuts.shortcutListItem('Step playhead forward'),
+    ).toBeVisible()
+
+    await fightPage.shortcuts.closeWithEscape()
+  })
 })

--- a/apps/web/src/pages/fight-page.tsx
+++ b/apps/web/src/pages/fight-page.tsx
@@ -168,7 +168,7 @@ export const FightPage: FC = () => {
     handleToggleFocusedPlayerIsolation,
     handleBossDamageModeChange,
     handleInferThreatReductionChange,
-    handlePlayheadChange,
+    handleReplayStateChange,
     handleSeriesClick,
     handleShowFixateBandsChange,
     handleShowEnergizeEventsChange,
@@ -205,7 +205,8 @@ export const FightPage: FC = () => {
 
   const replayMode = useReplayMode({
     committedPlayheadMs: queryState.state.playheadMs,
-    onCommit: handlePlayheadChange,
+    committedReplay: queryState.state.replay,
+    onCommitState: handleReplayStateChange,
     resetZoom: () => {
       registeredResetZoom?.()
     },
@@ -314,10 +315,7 @@ export const FightPage: FC = () => {
     },
     {
       description: 'Toggle replay mode',
-      metadata: {
-        order: 70,
-        showInFightOverlay: true,
-      },
+      metadata: { group: 'Replay', order: 70, showInFightOverlay: true },
       scopes: ['fight-page'],
     },
     [replayMode.toggleReplayMode],
@@ -326,19 +324,13 @@ export const FightPage: FC = () => {
   useHotkeys(
     'space',
     (event) => {
-      if (!replayMode.isReplayMode) {
-        return
-      }
-
+      if (!replayMode.isReplayMode) return
       event.preventDefault()
       replayMode.togglePlayPause()
     },
     {
       description: 'Play / Pause',
-      metadata: {
-        order: 71,
-        showInFightOverlay: true,
-      },
+      metadata: { group: 'Replay', order: 71, showInFightOverlay: true },
       scopes: ['fight-page'],
     },
     [replayMode.isReplayMode, replayMode.togglePlayPause],
@@ -347,15 +339,13 @@ export const FightPage: FC = () => {
   useHotkeys(
     'escape',
     (event) => {
-      if (!replayMode.isReplayMode) {
-        return
-      }
-
+      if (!replayMode.isReplayMode) return
       event.preventDefault()
       replayMode.exitReplayMode()
     },
     {
       description: 'Exit replay mode',
+      metadata: { group: 'Replay', order: 72, showInFightOverlay: true },
       scopes: ['fight-page'],
     },
     [replayMode.isReplayMode, replayMode.exitReplayMode],
@@ -364,15 +354,13 @@ export const FightPage: FC = () => {
   useHotkeys(
     'shift+.',
     (event) => {
-      if (!replayMode.isReplayMode) {
-        return
-      }
-
+      if (!replayMode.isReplayMode) return
       event.preventDefault()
       replayMode.increaseSpeed()
     },
     {
       description: 'Increase playback speed',
+      metadata: { group: 'Replay', order: 73, showInFightOverlay: true },
       scopes: ['fight-page'],
     },
     [replayMode.isReplayMode, replayMode.increaseSpeed],
@@ -381,15 +369,13 @@ export const FightPage: FC = () => {
   useHotkeys(
     'shift+,',
     (event) => {
-      if (!replayMode.isReplayMode) {
-        return
-      }
-
+      if (!replayMode.isReplayMode) return
       event.preventDefault()
       replayMode.decreaseSpeed()
     },
     {
       description: 'Decrease playback speed',
+      metadata: { group: 'Replay', order: 74, showInFightOverlay: true },
       scopes: ['fight-page'],
     },
     [replayMode.isReplayMode, replayMode.decreaseSpeed],
@@ -398,35 +384,31 @@ export const FightPage: FC = () => {
   useHotkeys(
     'right',
     (event) => {
-      if (replayMode.effectivePlayheadMs === null) {
-        return
-      }
-
+      if (!replayMode.isReplayMode) return
       event.preventDefault()
       replayMode.stepForward(event.shiftKey)
     },
     {
       description: 'Step playhead forward',
+      metadata: { group: 'Replay', order: 75, showInFightOverlay: true },
       scopes: ['fight-page'],
     },
-    [replayMode.effectivePlayheadMs, replayMode.stepForward],
+    [replayMode.isReplayMode, replayMode.stepForward],
   )
 
   useHotkeys(
     'left',
     (event) => {
-      if (replayMode.effectivePlayheadMs === null) {
-        return
-      }
-
+      if (!replayMode.isReplayMode) return
       event.preventDefault()
       replayMode.stepBackward(event.shiftKey)
     },
     {
       description: 'Step playhead backward',
+      metadata: { group: 'Replay', order: 76, showInFightOverlay: true },
       scopes: ['fight-page'],
     },
-    [replayMode.effectivePlayheadMs, replayMode.stepBackward],
+    [replayMode.isReplayMode, replayMode.stepBackward],
   )
 
   if (!reportId || Number.isNaN(fightId)) {

--- a/apps/web/src/pages/fight-page.tsx
+++ b/apps/web/src/pages/fight-page.tsx
@@ -352,7 +352,7 @@ export const FightPage: FC = () => {
   )
 
   useHotkeys(
-    'shift+.',
+    'shift+period',
     (event) => {
       if (!replayMode.isReplayMode) return
       event.preventDefault()
@@ -367,7 +367,7 @@ export const FightPage: FC = () => {
   )
 
   useHotkeys(
-    'shift+,',
+    'shift+comma',
     (event) => {
       if (!replayMode.isReplayMode) return
       event.preventDefault()

--- a/apps/web/src/pages/fight-page.tsx
+++ b/apps/web/src/pages/fight-page.tsx
@@ -16,17 +16,21 @@ import { useLocation, useParams } from 'react-router-dom'
 
 import { ErrorBoundary } from '../components/error-boundary'
 import { ErrorState } from '../components/error-state'
+import { PlaybackControls } from '../components/playback-controls'
 import { PlayerSummaryTable } from '../components/player-summary-table'
 import { SectionCard } from '../components/section-card'
 import { TargetSelector } from '../components/target-selector'
 import { ThreatChart, type ThreatChartProps } from '../components/threat-chart'
 import { ThreatChartControls } from '../components/threat-chart-controls'
+import { ThreatMeter } from '../components/threat-meter'
 import { Skeleton } from '../components/ui/skeleton'
 import { useFightData } from '../hooks/use-fight-data'
 import { useFightEvents } from '../hooks/use-fight-events'
+import { useReplayMode } from '../hooks/use-replay-mode'
 import { useUserSettings } from '../hooks/use-user-settings'
 import { formatClockDuration } from '../lib/format'
 import { parseBooleanQueryParam } from '../lib/query-params'
+import { getThreatAtTime } from '../lib/threat-at-time'
 import { resolveCurrentThreatConfig } from '../lib/threat-config'
 import { buildCharacterUrl, buildFightRankingsUrl } from '../lib/wcl-url'
 import { useReportRouteContext } from '../routes/report-layout-context'
@@ -136,6 +140,7 @@ export const FightPage: FC = () => {
   const eventsData = eventsQuery.data ?? null
 
   const {
+    allSeries,
     focusedPlayerRows,
     focusedPlayerSummary,
     initialAuras,
@@ -163,6 +168,7 @@ export const FightPage: FC = () => {
     handleToggleFocusedPlayerIsolation,
     handleBossDamageModeChange,
     handleInferThreatReductionChange,
+    handlePlayheadChange,
     handleSeriesClick,
     handleShowFixateBandsChange,
     handleShowEnergizeEventsChange,
@@ -196,6 +202,22 @@ export const FightPage: FC = () => {
     },
     [],
   )
+
+  const replayMode = useReplayMode({
+    committedPlayheadMs: queryState.state.playheadMs,
+    onCommit: handlePlayheadChange,
+    resetZoom: () => {
+      registeredResetZoom?.()
+    },
+    maxMs: fightDurationMs,
+  })
+
+  const threatAtPlayhead =
+    replayMode.effectivePlayheadMs !== null
+      ? getThreatAtTime(allSeries, replayMode.effectivePlayheadMs)
+      : null
+
+  const [isThreatMeterExpanded, setIsThreatMeterExpanded] = useState(false)
 
   useEffect(() => {
     enableScope('fight-page')
@@ -282,6 +304,129 @@ export const FightPage: FC = () => {
       scopes: ['fight-page'],
     },
     [handleShowEnergizeEventsChange, userSettings.showEnergizeEvents],
+  )
+
+  useHotkeys(
+    'r',
+    (event) => {
+      event.preventDefault()
+      replayMode.toggleReplayMode()
+    },
+    {
+      description: 'Toggle replay mode',
+      metadata: {
+        order: 70,
+        showInFightOverlay: true,
+      },
+      scopes: ['fight-page'],
+    },
+    [replayMode.toggleReplayMode],
+  )
+
+  useHotkeys(
+    'space',
+    (event) => {
+      if (!replayMode.isReplayMode) {
+        return
+      }
+
+      event.preventDefault()
+      replayMode.togglePlayPause()
+    },
+    {
+      description: 'Play / Pause',
+      metadata: {
+        order: 71,
+        showInFightOverlay: true,
+      },
+      scopes: ['fight-page'],
+    },
+    [replayMode.isReplayMode, replayMode.togglePlayPause],
+  )
+
+  useHotkeys(
+    'escape',
+    (event) => {
+      if (!replayMode.isReplayMode) {
+        return
+      }
+
+      event.preventDefault()
+      replayMode.exitReplayMode()
+    },
+    {
+      description: 'Exit replay mode',
+      scopes: ['fight-page'],
+    },
+    [replayMode.isReplayMode, replayMode.exitReplayMode],
+  )
+
+  useHotkeys(
+    'shift+.',
+    (event) => {
+      if (!replayMode.isReplayMode) {
+        return
+      }
+
+      event.preventDefault()
+      replayMode.increaseSpeed()
+    },
+    {
+      description: 'Increase playback speed',
+      scopes: ['fight-page'],
+    },
+    [replayMode.isReplayMode, replayMode.increaseSpeed],
+  )
+
+  useHotkeys(
+    'shift+,',
+    (event) => {
+      if (!replayMode.isReplayMode) {
+        return
+      }
+
+      event.preventDefault()
+      replayMode.decreaseSpeed()
+    },
+    {
+      description: 'Decrease playback speed',
+      scopes: ['fight-page'],
+    },
+    [replayMode.isReplayMode, replayMode.decreaseSpeed],
+  )
+
+  useHotkeys(
+    'right',
+    (event) => {
+      if (replayMode.effectivePlayheadMs === null) {
+        return
+      }
+
+      event.preventDefault()
+      replayMode.stepForward(event.shiftKey)
+    },
+    {
+      description: 'Step playhead forward',
+      scopes: ['fight-page'],
+    },
+    [replayMode.effectivePlayheadMs, replayMode.stepForward],
+  )
+
+  useHotkeys(
+    'left',
+    (event) => {
+      if (replayMode.effectivePlayheadMs === null) {
+        return
+      }
+
+      event.preventDefault()
+      replayMode.stepBackward(event.shiftKey)
+    },
+    {
+      description: 'Step playhead backward',
+      scopes: ['fight-page'],
+    },
+    [replayMode.effectivePlayheadMs, replayMode.stepBackward],
   )
 
   if (!reportId || Number.isNaN(fightId)) {
@@ -371,6 +516,20 @@ export const FightPage: FC = () => {
     onChartReadyChange: setIsChartReady,
     onRegisterResetZoom: handleRegisterResetZoom,
     targetDeathTimeMs,
+    isReplayMode: replayMode.isReplayMode,
+    playheadMs: replayMode.effectivePlayheadMs,
+    onPlayheadChange: replayMode.setPlayheadMs,
+    rightPanel:
+      replayMode.isReplayMode && threatAtPlayhead ? (
+        <ThreatMeter
+          entries={threatAtPlayhead}
+          focusedActorId={queryState.state.focusId}
+          selectedPlayerIds={queryState.state.players}
+          playheadMs={replayMode.effectivePlayheadMs ?? 0}
+          isExpanded={isThreatMeterExpanded}
+          onExpandedChange={setIsThreatMeterExpanded}
+        />
+      ) : undefined,
   }
 
   const fightTimelineTitle = (
@@ -438,22 +597,37 @@ export const FightPage: FC = () => {
           {isUserSettingsLoading ? (
             <FightChartLoadingSkeleton loadingMessage="Loading fight settings" />
           ) : (
-            <ThreatChartControls
-              onResetZoom={() => {
-                registeredResetZoom?.()
-              }}
-              isResetZoomDisabled={
-                !isChartReady || registeredResetZoom === null
-              }
-              showFixateBands={userSettings.showFixateBands}
-              onShowFixateBandsChange={handleShowFixateBandsChange}
-              showEnergizeEvents={userSettings.showEnergizeEvents}
-              onShowEnergizeEventsChange={handleShowEnergizeEventsChange}
-              bossDamageMode={bossDamageMode}
-              onBossDamageModeChange={handleBossDamageModeChange}
-              inferThreatReduction={userSettings.inferThreatReduction}
-              onInferThreatReductionChange={handleInferThreatReductionChange}
-            />
+            <>
+              <ThreatChartControls
+                onResetZoom={() => {
+                  registeredResetZoom?.()
+                }}
+                isResetZoomDisabled={
+                  !isChartReady ||
+                  registeredResetZoom === null ||
+                  replayMode.isReplayMode
+                }
+                showFixateBands={userSettings.showFixateBands}
+                onShowFixateBandsChange={handleShowFixateBandsChange}
+                showEnergizeEvents={userSettings.showEnergizeEvents}
+                onShowEnergizeEventsChange={handleShowEnergizeEventsChange}
+                bossDamageMode={bossDamageMode}
+                onBossDamageModeChange={handleBossDamageModeChange}
+                inferThreatReduction={userSettings.inferThreatReduction}
+                onInferThreatReductionChange={handleInferThreatReductionChange}
+              />
+              <PlaybackControls
+                isPlaying={replayMode.isPlaying}
+                isReplayMode={replayMode.isReplayMode}
+                playbackSpeed={replayMode.playbackSpeed}
+                hasPlayhead={replayMode.effectivePlayheadMs !== null}
+                onTogglePlayPause={replayMode.togglePlayPause}
+                onIncreaseSpeed={replayMode.increaseSpeed}
+                onDecreaseSpeed={replayMode.decreaseSpeed}
+                onToggleReplayMode={replayMode.toggleReplayMode}
+                onClearPlayhead={replayMode.clearPlayhead}
+              />
+            </>
           )}
 
           {isUserSettingsLoading ? null : selectedTarget === null ? (

--- a/apps/web/src/pages/hooks/use-fight-page-derived-state.ts
+++ b/apps/web/src/pages/hooks/use-fight-page-derived-state.ts
@@ -84,6 +84,7 @@ function resolveFocusedPlayerId({
 }
 
 export interface UseFightPageDerivedStateResult {
+  allSeries: ThreatSeries[]
   durationMs: number
   focusedPlayerRows: ReturnType<typeof buildFocusedPlayerAggregation>['rows']
   focusedPlayerSummary: ReturnType<
@@ -305,6 +306,7 @@ export function useFightPageDerivedState({
   const wowheadLinksConfig = threatConfig?.wowhead ?? defaultWowheadLinksConfig
 
   return {
+    allSeries,
     durationMs,
     focusedPlayerRows: focusedPlayerAggregation.rows,
     focusedPlayerSummary: focusedPlayerAggregation.summary,

--- a/apps/web/src/pages/hooks/use-fight-page-interactions.ts
+++ b/apps/web/src/pages/hooks/use-fight-page-interactions.ts
@@ -28,6 +28,7 @@ export interface UseFightPageInteractionsResult {
   handleBossDamageModeChange: (bossDamageMode: BossDamageMode) => void
   handleClearSelections: () => void
   handleInferThreatReductionChange: (inferThreatReduction: boolean) => void
+  handlePlayheadChange: (playheadMs: number | null) => void
   handleSeriesClick: (playerId: number) => void
   handleShowFixateBandsChange: (showFixateBands: boolean) => void
   handleShowEnergizeEventsChange: (showEnergizeEvents: boolean) => void
@@ -48,6 +49,7 @@ export function useFightPageInteractions({
     UseFightQueryStateResult,
     | 'setFocusAndPlayers'
     | 'setFocusId'
+    | 'setPlayheadMs'
     | 'setPinnedPlayers'
     | 'setPlayers'
     | 'setTarget'
@@ -240,6 +242,13 @@ export function useFightPageInteractions({
     [updateUserSettings],
   )
 
+  const handlePlayheadChange = useCallback(
+    (playheadMs: number | null): void => {
+      queryState.setPlayheadMs(playheadMs)
+    },
+    [queryState],
+  )
+
   return {
     handleClearSelections,
     handleFocusAndAddPlayer,
@@ -247,6 +256,7 @@ export function useFightPageInteractions({
     handleToggleFocusedPlayerIsolation,
     handleBossDamageModeChange,
     handleInferThreatReductionChange,
+    handlePlayheadChange,
     handleSeriesClick,
     handleShowFixateBandsChange,
     handleShowEnergizeEventsChange,

--- a/apps/web/src/pages/hooks/use-fight-page-interactions.ts
+++ b/apps/web/src/pages/hooks/use-fight-page-interactions.ts
@@ -28,7 +28,10 @@ export interface UseFightPageInteractionsResult {
   handleBossDamageModeChange: (bossDamageMode: BossDamageMode) => void
   handleClearSelections: () => void
   handleInferThreatReductionChange: (inferThreatReduction: boolean) => void
-  handlePlayheadChange: (playheadMs: number | null) => void
+  handleReplayStateChange: (state: {
+    playheadMs?: number | null
+    replay?: boolean
+  }) => void
   handleSeriesClick: (playerId: number) => void
   handleShowFixateBandsChange: (showFixateBands: boolean) => void
   handleShowEnergizeEventsChange: (showEnergizeEvents: boolean) => void
@@ -49,7 +52,7 @@ export function useFightPageInteractions({
     UseFightQueryStateResult,
     | 'setFocusAndPlayers'
     | 'setFocusId'
-    | 'setPlayheadMs'
+    | 'setReplayState'
     | 'setPinnedPlayers'
     | 'setPlayers'
     | 'setTarget'
@@ -242,9 +245,9 @@ export function useFightPageInteractions({
     [updateUserSettings],
   )
 
-  const handlePlayheadChange = useCallback(
-    (playheadMs: number | null): void => {
-      queryState.setPlayheadMs(playheadMs)
+  const handleReplayStateChange = useCallback(
+    (state: { playheadMs?: number | null; replay?: boolean }): void => {
+      queryState.setReplayState(state)
     },
     [queryState],
   )
@@ -256,7 +259,7 @@ export function useFightPageInteractions({
     handleToggleFocusedPlayerIsolation,
     handleBossDamageModeChange,
     handleInferThreatReductionChange,
-    handlePlayheadChange,
+    handleReplayStateChange,
     handleSeriesClick,
     handleShowFixateBandsChange,
     handleShowEnergizeEventsChange,

--- a/apps/web/src/test/page-objects/components/keyboard-shortcuts-overlay-object.ts
+++ b/apps/web/src/test/page-objects/components/keyboard-shortcuts-overlay-object.ts
@@ -14,6 +14,10 @@ export class KeyboardShortcutsOverlayObject {
     return this.page.getByRole('dialog', { name: 'Keyboard shortcuts' })
   }
 
+  groupHeading(name: string): Locator {
+    return this.dialog().locator('h3').filter({ hasText: name }).first()
+  }
+
   shortcutListItem(description: string): Locator {
     return this.dialog()
       .getByRole('listitem')

--- a/apps/web/src/test/page-objects/fight-page/fight-page-object.ts
+++ b/apps/web/src/test/page-objects/fight-page/fight-page-object.ts
@@ -7,12 +7,14 @@ import { FightQuickSwitcherObject } from '../components/fight-quick-switcher-obj
 import { KeyboardShortcutsOverlayObject } from '../components/keyboard-shortcuts-overlay-object'
 import { FightPageHeaderObject } from './fight-page-header-object'
 import { FocusedPlayerSummaryObject } from './focused-player-summary-object'
+import { ReplayModeObject } from './replay-mode-object'
 import { ThreatChartObject } from './threat-chart-object'
 
 export class FightPageObject {
   readonly chart: ThreatChartObject
   readonly header: FightPageHeaderObject
   readonly quickSwitch: FightQuickSwitcherObject
+  readonly replay: ReplayModeObject
   readonly shortcuts: KeyboardShortcutsOverlayObject
   readonly summary: FocusedPlayerSummaryObject
 
@@ -20,6 +22,7 @@ export class FightPageObject {
     this.header = new FightPageHeaderObject(page)
     this.quickSwitch = new FightQuickSwitcherObject(page)
     this.chart = new ThreatChartObject(page)
+    this.replay = new ReplayModeObject(page)
     this.shortcuts = new KeyboardShortcutsOverlayObject(page)
     this.summary = new FocusedPlayerSummaryObject(page)
   }

--- a/apps/web/src/test/page-objects/fight-page/index.ts
+++ b/apps/web/src/test/page-objects/fight-page/index.ts
@@ -5,4 +5,5 @@ export { FightQuickSwitcherObject } from '../components/fight-quick-switcher-obj
 export { FightPageHeaderObject } from './fight-page-header-object'
 export { FightPageObject } from './fight-page-object'
 export { FocusedPlayerSummaryObject } from './focused-player-summary-object'
+export { ReplayModeObject } from './replay-mode-object'
 export { ThreatChartObject } from './threat-chart-object'

--- a/apps/web/src/test/page-objects/fight-page/replay-mode-object.ts
+++ b/apps/web/src/test/page-objects/fight-page/replay-mode-object.ts
@@ -1,0 +1,46 @@
+/**
+ * Page object for replay mode interactions on the fight page.
+ */
+import { type Locator, type Page } from '@playwright/test'
+
+export class ReplayModeObject {
+  constructor(private readonly page: Page) {}
+
+  replayButton(): Locator {
+    return this.page.getByRole('button', { name: 'Replay', exact: true })
+  }
+
+  resumeReplayButton(): Locator {
+    return this.page.getByRole('button', {
+      name: 'Resume Replay',
+      exact: true,
+    })
+  }
+
+  exitReplayButton(): Locator {
+    return this.page.getByRole('button', {
+      name: 'Exit Replay',
+      exact: true,
+    })
+  }
+
+  playPauseButton(): Locator {
+    return this.page.getByRole('button', { name: /^(Play|Pause)$/ }).first()
+  }
+
+  threatMeter(): Locator {
+    return this.page.getByTestId('threat-meter')
+  }
+
+  async enterWithKey(): Promise<void> {
+    await this.page.keyboard.press('r')
+  }
+
+  async exitWithKey(): Promise<void> {
+    await this.page.keyboard.press('r')
+  }
+
+  async exitWithEscape(): Promise<void> {
+    await this.page.keyboard.press('Escape')
+  }
+}

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -85,6 +85,7 @@ export interface FightQueryState {
   startMs: number | null
   endMs: number | null
   playheadMs: number | null
+  replay: boolean
 }
 
 export interface FightTarget {

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -84,6 +84,7 @@ export interface FightQueryState {
   targetInstance: number | null
   startMs: number | null
   endMs: number | null
+  playheadMs: number | null
 }
 
 export interface FightTarget {


### PR DESCRIPTION
## Summary

- Adds a **replay mode** to the fight chart, toggled by pressing `R`, enabling real-time playback and scrubbing of threat data
- In replay mode: click/drag places a playhead, the right-side legend is replaced by a ranked **threat meter** bar chart, and playback animates at adjustable speed (0.25x–2x)
- `playheadMs` and `replay` query params enable URL sharing of exact replay state
- Keyboard shortcuts are grouped into "Chart" and "Replay" sections in the shortcuts overlay

### New files
- `use-replay-mode.ts` — central hook for mode, playback (rAF), speed, stepping
- `use-threat-chart-playhead.ts` — ZRender click/drag-to-scrub interaction
- `threat-at-time.ts` — binary search for threat values at a timestamp
- `threat-meter.tsx` — ranked bar chart component
- `playback-controls.tsx` — play/pause, speed, mode toggle buttons
- `replay-mode-object.ts` — Playwright page object

### Keyboard shortcuts
| Key | Action |
|-----|--------|
| `R` | Toggle replay mode |
| `Space` | Play / Pause |
| `Escape` | Exit replay mode |
| `<` / `>` | Decrease / increase playback speed |
| `←` / `→` | Step ±1s |
| `Shift+←` / `Shift+→` | Step ±100ms |

Recording:



https://github.com/user-attachments/assets/9f14805d-cf33-4a90-aeed-48e7ef3207a3





## Test plan
- [x] Unit tests: 348 passing (18 new for `use-replay-mode`, 10 for `threat-at-time`, 7 for `threat-meter`, 5 for `search-params`)
- [x] E2E tests: 30 passing (4 new: enter/exit replay, deep-link, grouped shortcuts overlay)
- [x] Typecheck + lint clean
- [ ] Manual: load fight → press R → scrub/play → share URL → verify recipient sees replay state

🤖 Generated with [Claude Code](https://claude.com/claude-code)