### PR TITLE
fix(engine): remove bloodlust/heroism as party group signal

### DIFF
--- a/packages/engine/src/processors/party-detection.ts
+++ b/packages/engine/src/processors/party-detection.ts
@@ -131,13 +131,15 @@ const PARTY_SIGNAL_DEFINITIONS: readonly PartySignalDefinition[] = [
     eventTypes: new Set(['applybuff', 'refreshbuff', 'applybuffstack']),
     matchName: (normalizedName) => normalizedName.includes('unleashed rage'),
   },
-  {
-    fallbackSpellIds: [2825, 32182],
-    eventTypes: new Set(['applybuff', 'refreshbuff', 'applybuffstack']),
-    matchName: (normalizedName) =>
-      normalizedName.includes('bloodlust') ||
-      normalizedName.includes('heroism'),
-  },
+  // removed because its common that shamans are swapped into a dps group for
+  // bloodlust and then swapped back out.
+  // {
+  //   fallbackSpellIds: [2825, 32182],
+  //   eventTypes: new Set(['applybuff', 'refreshbuff', 'applybuffstack']),
+  //   matchName: (normalizedName) =>
+  //     normalizedName.includes('bloodlust') ||
+  //     normalizedName.includes('heroism'),
+  // },
   {
     fallbackSpellIds: [27045],
     eventTypes: new Set(['applybuff', 'refreshbuff', 'applybuffstack']),


### PR DESCRIPTION
## Description

Removes bloodlust/heroism from the party signal definitions used to infer which group a player belongs to.

Bloodlust is unreliable as a party detection signal because it's common practice to swap a shaman into a DPS group specifically to cast bloodlust and then swap them back out. Using this as a signal causes incorrect group assignments.

## Validation

- Existing party-detection tests pass
- No threat engine behavior changes outside of party grouping for shaman bloodlust scenarios

## Risks

- Party group detection may be slightly less accurate in logs where bloodlust was the only available signal (no other group-correlated buffs)

## Visuals

- N/A