### PR TITLE
feat(chrome-extension): add WCL browser extension

### DIFF
--- a/packages/chrome-extension/README.md
+++ b/packages/chrome-extension/README.md
@@ -1,0 +1,28 @@
+# WoW Threat — Chrome Extension
+
+Injects a **Threat** tab button into Warcraft Logs report pages that opens the current fight in [wow-threat.web.app](https://wow-threat.web.app).
+
+## Installing (load unpacked)
+
+1. Open Chrome and go to `chrome://extensions`
+2. Enable **Developer mode** (toggle in the top-right corner)
+3. Click **Load unpacked**
+4. Select the `packages/chrome-extension/` directory from this repo
+
+The extension icon will appear in your toolbar.
+
+## Usage
+
+Navigate to any WCL report page (classic, vanilla, fresh, SoD, or retail). A **Threat** tab appears in the report's tab bar. Clicking it opens the current fight with the selected player pre-filled in wow-threat.
+
+## Switching to localhost
+
+Click the extension icon to open the popup. Click **Switch to Localhost :5173** to point all Threat links at your local dev server. Click again to switch back to production.
+
+## Supported sites
+
+- `classic.warcraftlogs.com`
+- `vanilla.warcraftlogs.com`
+- `fresh.warcraftlogs.com`
+- `sod.warcraftlogs.com`
+- `www.warcraftlogs.com`

--- a/packages/chrome-extension/content.js
+++ b/packages/chrome-extension/content.js
@@ -63,35 +63,16 @@ function updateButton(baseUrl) {
   link.href = url
   link.target = '_blank'
   link.rel = 'noopener noreferrer'
-  link.style.cssText = 'position: relative; overflow: visible;'
-
   const icon = document.createElement('span')
   icon.className = 'zmdi zmdi-chart'
 
   const label = document.createElement('span')
   label.className = 'big-tab-text'
-  label.innerHTML = '<br>Threat'
-
-  const stamp = document.createElement('span')
-  stamp.textContent = 'WoW Threat'
-  stamp.style.cssText = [
-    'position: absolute',
-    'top: 6px',
-    'left: 50%',
-    'font-size: 7px',
-    'font-weight: 700',
-    'letter-spacing: 0.03em',
-    'color: #cc2200',
-    'transform: translateX(-50%) rotate(10deg)',
-    'pointer-events: none',
-    'line-height: 1',
-    'white-space: nowrap',
-    'text-shadow: 0 0 4px rgba(0,0,0,0.8)',
-  ].join('; ')
+  label.style.color = '#cc2200'
+  label.innerHTML = '<br>WoW Threat'
 
   link.appendChild(icon)
   link.appendChild(label)
-  link.appendChild(stamp)
 
   tabContainer.appendChild(link)
 }

--- a/packages/chrome-extension/content.js
+++ b/packages/chrome-extension/content.js
@@ -64,6 +64,19 @@ function updateButton(baseUrl) {
   link.target = '_blank'
   link.rel = 'noopener noreferrer'
 
+  // Ascending bar chart icon — matches the threat-meter concept and WCL's tab icon style
+  const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  icon.setAttribute('viewBox', '0 0 24 24')
+  icon.setAttribute('width', '20')
+  icon.setAttribute('height', '20')
+  icon.setAttribute('fill', 'currentColor')
+  icon.setAttribute('aria-hidden', 'true')
+  icon.innerHTML =
+    '<rect x="2" y="14" width="5" height="8" rx="1"/>' +
+    '<rect x="9.5" y="8" width="5" height="14" rx="1"/>' +
+    '<rect x="17" y="2" width="5" height="20" rx="1"/>'
+  link.appendChild(icon)
+
   const label = document.createElement('span')
   label.textContent = 'Threat'
   link.appendChild(label)

--- a/packages/chrome-extension/content.js
+++ b/packages/chrome-extension/content.js
@@ -1,0 +1,123 @@
+/**
+ * content.js — injects a "Threat" tab button into WCL report pages.
+ *
+ * Builds a deep-link to wow-threat.web.app (or localhost:5173) using the
+ * report code, fight ID, and selected source from the current WCL URL.
+ */
+
+const PROD_BASE = 'https://wow-threat.web.app'
+const LOCAL_BASE = 'http://localhost:5173'
+const BUTTON_ID = 'wow-threat-link'
+
+/** Extract the WCL report code from the current pathname. */
+function getReportCode() {
+  return location.pathname.match(/\/reports\/([A-Za-z0-9]+)/)?.[1] ?? null
+}
+
+/** Build the wow-threat deep-link URL from the current page state. */
+function buildUrl(baseUrl) {
+  const reportCode = getReportCode()
+  if (!reportCode) return null
+
+  // WCL puts fight and source in the query string (?fight=26&source=113)
+  const params = new URLSearchParams(location.search)
+  const fightId = params.get('fight')
+  const sourceId = params.get('source')
+
+  if (!fightId || fightId === 'last') {
+    return `${baseUrl}/report/${reportCode}`
+  }
+
+  const url = new URL(`${baseUrl}/report/${reportCode}/fight/${fightId}`)
+  if (sourceId) {
+    const sources = sourceId.split(',')
+    if (sources.length === 1) {
+      url.searchParams.set('focusId', sourceId)
+    } else {
+      url.searchParams.set('players', sourceId)
+    }
+  }
+  return url.toString()
+}
+
+/** Create or update the threat tab button href. */
+function updateButton(baseUrl) {
+  const existing = document.getElementById(BUTTON_ID)
+  const url = buildUrl(baseUrl)
+
+  if (existing) {
+    if (url) {
+      existing.href = url
+    }
+    return
+  }
+
+  if (!url) return
+
+  const tabContainer = document.getElementById('top-level-view-tabs')
+  if (!tabContainer) return
+
+  const link = document.createElement('a')
+  link.id = BUTTON_ID
+  link.className = 'big-tab view-type-tab'
+  link.href = url
+  link.target = '_blank'
+  link.rel = 'noopener noreferrer'
+
+  const label = document.createElement('span')
+  label.textContent = 'Threat'
+  link.appendChild(label)
+
+  tabContainer.appendChild(link)
+}
+
+/** Wait for the tab container to appear then inject the button. */
+function waitForTabContainer(baseUrl) {
+  const existing = document.getElementById('top-level-view-tabs')
+  if (existing) {
+    updateButton(baseUrl)
+    return
+  }
+
+  const observer = new MutationObserver(() => {
+    if (document.getElementById('top-level-view-tabs')) {
+      observer.disconnect()
+      updateButton(baseUrl)
+    }
+  })
+
+  observer.observe(document.body, { childList: true, subtree: true })
+
+  // Stop observing after 10 seconds to avoid leaking
+  setTimeout(() => observer.disconnect(), 10_000)
+}
+
+/** Re-read storage and refresh the button href. */
+function onUrlChange() {
+  chrome.storage.local.get({ mode: 'prod' }, ({ mode }) => {
+    updateButton(mode === 'local' ? LOCAL_BASE : PROD_BASE)
+  })
+}
+
+/**
+ * Patch history.pushState and history.replaceState to fire a custom event.
+ * WCL is a SPA that navigates via pushState — hashchange won't fire.
+ */
+function patchHistory() {
+  for (const method of ['pushState', 'replaceState']) {
+    const original = history[method].bind(history)
+    history[method] = (...args) => {
+      original(...args)
+      window.dispatchEvent(new Event('wow-threat:urlchange'))
+    }
+  }
+  window.addEventListener('popstate', onUrlChange)
+  window.addEventListener('wow-threat:urlchange', onUrlChange)
+}
+
+/** Initialise the extension: load mode from storage and set up the button. */
+chrome.storage.local.get({ mode: 'prod' }, ({ mode }) => {
+  const baseUrl = mode === 'local' ? LOCAL_BASE : PROD_BASE
+  patchHistory()
+  waitForTabContainer(baseUrl)
+})

--- a/packages/chrome-extension/content.js
+++ b/packages/chrome-extension/content.js
@@ -64,21 +64,14 @@ function updateButton(baseUrl) {
   link.target = '_blank'
   link.rel = 'noopener noreferrer'
 
-  // Ascending bar chart icon — matches the threat-meter concept and WCL's tab icon style
-  const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-  icon.setAttribute('viewBox', '0 0 24 24')
-  icon.setAttribute('width', '20')
-  icon.setAttribute('height', '20')
-  icon.setAttribute('fill', 'currentColor')
-  icon.setAttribute('aria-hidden', 'true')
-  icon.innerHTML =
-    '<rect x="2" y="14" width="5" height="8" rx="1"/>' +
-    '<rect x="9.5" y="8" width="5" height="14" rx="1"/>' +
-    '<rect x="17" y="2" width="5" height="20" rx="1"/>'
-  link.appendChild(icon)
+  const icon = document.createElement('span')
+  icon.className = 'zmdi zmdi-chart'
 
   const label = document.createElement('span')
+  label.className = 'big-tab-text'
   label.textContent = 'Threat'
+
+  link.appendChild(icon)
   link.appendChild(label)
 
   tabContainer.appendChild(link)

--- a/packages/chrome-extension/content.js
+++ b/packages/chrome-extension/content.js
@@ -69,7 +69,7 @@ function updateButton(baseUrl) {
 
   const label = document.createElement('span')
   label.className = 'big-tab-text'
-  label.textContent = 'Threat'
+  label.innerHTML = '<br>Threat'
 
   link.appendChild(icon)
   link.appendChild(label)
@@ -92,7 +92,8 @@ function waitForTabContainer(baseUrl) {
     }
   })
 
-  observer.observe(document.body, { childList: true, subtree: true })
+  // At document_start, document.body may not exist yet — observe from the root
+  observer.observe(document.documentElement, { childList: true, subtree: true })
 
   // Stop observing after 10 seconds to avoid leaking
   setTimeout(() => observer.disconnect(), 10_000)

--- a/packages/chrome-extension/content.js
+++ b/packages/chrome-extension/content.js
@@ -76,14 +76,13 @@ function updateButton(baseUrl) {
   stamp.textContent = 'WoW Threat'
   stamp.style.cssText = [
     'position: absolute',
-    'top: 2px',
-    'right: -4px',
+    'top: 6px',
+    'left: 50%',
     'font-size: 7px',
     'font-weight: 700',
     'letter-spacing: 0.03em',
     'color: #cc2200',
-    'transform: rotate(12deg)',
-    'transform-origin: top right',
+    'transform: translateX(-50%) rotate(10deg)',
     'pointer-events: none',
     'line-height: 1',
     'white-space: nowrap',

--- a/packages/chrome-extension/content.js
+++ b/packages/chrome-extension/content.js
@@ -63,6 +63,7 @@ function updateButton(baseUrl) {
   link.href = url
   link.target = '_blank'
   link.rel = 'noopener noreferrer'
+  link.style.cssText = 'position: relative; overflow: visible;'
 
   const icon = document.createElement('span')
   icon.className = 'zmdi zmdi-chart'
@@ -71,8 +72,27 @@ function updateButton(baseUrl) {
   label.className = 'big-tab-text'
   label.innerHTML = '<br>Threat'
 
+  const stamp = document.createElement('span')
+  stamp.textContent = 'WoW Threat'
+  stamp.style.cssText = [
+    'position: absolute',
+    'top: 2px',
+    'right: -4px',
+    'font-size: 7px',
+    'font-weight: 700',
+    'letter-spacing: 0.03em',
+    'color: #cc2200',
+    'transform: rotate(12deg)',
+    'transform-origin: top right',
+    'pointer-events: none',
+    'line-height: 1',
+    'white-space: nowrap',
+    'text-shadow: 0 0 4px rgba(0,0,0,0.8)',
+  ].join('; ')
+
   link.appendChild(icon)
   link.appendChild(label)
+  link.appendChild(stamp)
 
   tabContainer.appendChild(link)
 }

--- a/packages/chrome-extension/manifest.json
+++ b/packages/chrome-extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "WoW Threat",
+  "name": "WoW Threat Companion",
   "version": "1.0.0",
   "description": "Open the current WCL fight in wow-threat.web.app",
   "permissions": ["storage"],
@@ -13,7 +13,7 @@
   ],
   "action": {
     "default_popup": "popup.html",
-    "default_title": "WoW Threat"
+    "default_title": "WoW Threat Companion"
   },
   "content_scripts": [
     {

--- a/packages/chrome-extension/manifest.json
+++ b/packages/chrome-extension/manifest.json
@@ -25,7 +25,7 @@
         "*://www.warcraftlogs.com/reports/*"
       ],
       "js": ["content.js"],
-      "run_at": "document_idle"
+      "run_at": "document_start"
     }
   ]
 }

--- a/packages/chrome-extension/manifest.json
+++ b/packages/chrome-extension/manifest.json
@@ -1,0 +1,31 @@
+{
+  "manifest_version": 3,
+  "name": "WoW Threat",
+  "version": "1.0.0",
+  "description": "Open the current WCL fight in wow-threat.web.app",
+  "permissions": ["storage"],
+  "host_permissions": [
+    "*://classic.warcraftlogs.com/reports/*",
+    "*://vanilla.warcraftlogs.com/reports/*",
+    "*://fresh.warcraftlogs.com/reports/*",
+    "*://sod.warcraftlogs.com/reports/*",
+    "*://www.warcraftlogs.com/reports/*"
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "WoW Threat"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://classic.warcraftlogs.com/reports/*",
+        "*://vanilla.warcraftlogs.com/reports/*",
+        "*://fresh.warcraftlogs.com/reports/*",
+        "*://sod.warcraftlogs.com/reports/*",
+        "*://www.warcraftlogs.com/reports/*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/packages/chrome-extension/popup.html
+++ b/packages/chrome-extension/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>WoW Threat</title>
+    <title>WoW Threat Companion</title>
     <style>
       body {
         font-family: system-ui, sans-serif;
@@ -68,7 +68,7 @@
     </style>
   </head>
   <body>
-    <h1>WoW Threat</h1>
+    <h1>WoW Threat Companion</h1>
     <div class="mode-row">
       <span class="mode-label">Mode:</span>
       <span class="mode-value" id="mode-display"></span>

--- a/packages/chrome-extension/popup.html
+++ b/packages/chrome-extension/popup.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>WoW Threat</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        font-size: 14px;
+        margin: 0;
+        padding: 16px;
+        width: 220px;
+        background: #1a1a1a;
+        color: #e8e8e8;
+      }
+
+      h1 {
+        font-size: 14px;
+        font-weight: 600;
+        margin: 0 0 12px;
+        color: #f0c040;
+      }
+
+      .mode-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+      }
+
+      .mode-label {
+        font-size: 13px;
+        color: #ccc;
+      }
+
+      .mode-value {
+        font-size: 13px;
+        font-weight: 600;
+        color: #e8e8e8;
+      }
+
+      button {
+        margin-top: 14px;
+        width: 100%;
+        padding: 7px 0;
+        border: none;
+        border-radius: 4px;
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+        background: #3a3a3a;
+        color: #e8e8e8;
+        transition: background 0.15s;
+      }
+
+      button:hover {
+        background: #4a4a4a;
+      }
+
+      button.active-local {
+        background: #1a4a2a;
+        color: #6ddb8a;
+      }
+
+      button.active-local:hover {
+        background: #1f5a32;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>WoW Threat</h1>
+    <div class="mode-row">
+      <span class="mode-label">Mode:</span>
+      <span class="mode-value" id="mode-display"></span>
+    </div>
+    <button id="toggle-btn"></button>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/packages/chrome-extension/popup.js
+++ b/packages/chrome-extension/popup.js
@@ -1,0 +1,31 @@
+/**
+ * popup.js — manages the prod/localhost mode toggle.
+ */
+
+const modeDisplay = document.getElementById('mode-display')
+const toggleBtn = document.getElementById('toggle-btn')
+
+function render(mode) {
+  if (mode === 'local') {
+    modeDisplay.textContent = 'Localhost :5173'
+    toggleBtn.textContent = 'Switch to Production'
+    toggleBtn.className = 'active-local'
+  } else {
+    modeDisplay.textContent = 'Production'
+    toggleBtn.textContent = 'Switch to Localhost :5173'
+    toggleBtn.className = ''
+  }
+}
+
+chrome.storage.local.get({ mode: 'prod' }, ({ mode }) => {
+  render(mode)
+})
+
+toggleBtn.addEventListener('click', () => {
+  chrome.storage.local.get({ mode: 'prod' }, ({ mode }) => {
+    const next = mode === 'prod' ? 'local' : 'prod'
+    chrome.storage.local.set({ mode: next }, () => {
+      render(next)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a Chrome extension (Manifest V3) at `packages/chrome-extension/` that injects a **Threat** tab into Warcraft Logs report pages
- Button builds a direct deep-link to `wow-threat.web.app` with report code, fight ID, and player pre-filled — single player uses `?focusId=`, multiple players use `?players=1,2,3`
- Extension popup toggles between production and `localhost:5173` for local dev, persisted via `chrome.storage.local`
- Handles WCL's SPA navigation by patching `history.pushState`/`replaceState` so the link updates as fights are switched without a page reload
- Matches all five WCL subdomains: `classic`, `vanilla`, `fresh`, `sod`, `www`
- No build step — load unpacked from `packages/chrome-extension/`

## Test plan

- [x] Load extension unpacked from `packages/chrome-extension/` at `chrome://extensions`
- [x] Visit a WCL report with a fight selected (e.g. `https://fresh.warcraftlogs.com/reports/f9yPamzBxQqhGndZ?fight=26&source=113`) — confirm "Threat" tab appears in the tab bar
- [x] Click the tab — confirm it opens `https://wow-threat.web.app/report/<code>/fight/26?focusId=113`
- [x] Switch to a different fight in WCL — confirm the tab href updates without a page reload
- [x] Click extension icon → toggle to Localhost → confirm tab links to `http://localhost:5173`
- [x] Toggle back to Production — confirm it reverts

🤖 Generated with [Claude Code](https://claude.com/claude-code)