### PR TITLE
fix(api): suppress expected operational errors from Sentry

### DIFF
--- a/apps/api/src/middleware/error.test.ts
+++ b/apps/api/src/middleware/error.test.ts
@@ -19,6 +19,7 @@ import {
   unauthorized,
   wclApiError,
   wclRateLimited,
+  invalidGameVersion,
 } from './error'
 
 vi.mock('@sentry/cloudflare', () => ({
@@ -165,7 +166,7 @@ describe('errorHandler Sentry integration', () => {
     vi.clearAllMocks()
   })
 
-  it('calls captureException for 5xx AppErrors', async () => {
+  it('captures FIRESTORE_ERROR', async () => {
     app.get('/test', () => {
       throw firestoreError('DB connection failed')
     })
@@ -175,17 +176,26 @@ describe('errorHandler Sentry integration', () => {
     expect(Sentry.captureException).toHaveBeenCalledOnce()
   })
 
-  it('does not call captureException for 4xx AppErrors', async () => {
-    app.get('/test', () => {
-      throw invalidReportCode('bad!code')
-    })
+  it('captures INVALID_* errors — they may indicate a frontend bug', async () => {
+    for (const err of [
+      invalidReportCode('bad!code'),
+      invalidFightId('abc'),
+      invalidGameVersion(99, [1, 2]),
+    ]) {
+      vi.clearAllMocks()
+      app = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+      app.onError(errorHandler)
+      app.get('/test', () => {
+        throw err
+      })
 
-    await app.request('http://localhost/test', {}, createMockBindings())
+      await app.request('http://localhost/test', {}, createMockBindings())
 
-    expect(Sentry.captureException).not.toHaveBeenCalled()
+      expect(Sentry.captureException).toHaveBeenCalledOnce()
+    }
   })
 
-  it('does not call captureException for 404 AppErrors', async () => {
+  it('does not capture REPORT_NOT_FOUND', async () => {
     app.get('/test', () => {
       throw reportNotFound('ABC123')
     })
@@ -195,7 +205,47 @@ describe('errorHandler Sentry integration', () => {
     expect(Sentry.captureException).not.toHaveBeenCalled()
   })
 
-  it('calls captureException for unknown errors', async () => {
+  it('does not capture FIGHT_NOT_FOUND', async () => {
+    app.get('/test', () => {
+      throw fightNotFound('ABC123', 5)
+    })
+
+    await app.request('http://localhost/test', {}, createMockBindings())
+
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+  })
+
+  it('does not capture WCL_API_ERROR', async () => {
+    app.get('/test', () => {
+      throw wclApiError('WCL returned 503')
+    })
+
+    await app.request('http://localhost/test', {}, createMockBindings())
+
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+  })
+
+  it('does not capture WCL_RATE_LIMITED', async () => {
+    app.get('/test', () => {
+      throw wclRateLimited()
+    })
+
+    await app.request('http://localhost/test', {}, createMockBindings())
+
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+  })
+
+  it('does not capture UNAUTHORIZED', async () => {
+    app.get('/test', () => {
+      throw unauthorized()
+    })
+
+    await app.request('http://localhost/test', {}, createMockBindings())
+
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+  })
+
+  it('captures unknown errors', async () => {
     app.get('/test', () => {
       throw new Error('Unexpected failure')
     })
@@ -205,7 +255,7 @@ describe('errorHandler Sentry integration', () => {
     expect(Sentry.captureException).toHaveBeenCalledOnce()
   })
 
-  it('calls captureException with the original error', async () => {
+  it('captures with the original error instance', async () => {
     const err = firestoreError('DB error')
     app.get('/test', () => {
       throw err

--- a/apps/api/src/middleware/error.ts
+++ b/apps/api/src/middleware/error.ts
@@ -142,6 +142,17 @@ export function firestoreError(message: string): AppError {
   return new AppError(ErrorCodes.FIRESTORE_ERROR, message, 500)
 }
 
+// Errors that are expected operational noise — suppress from Sentry alerts.
+// INVALID_* codes are intentionally excluded: they arrive via the app's own
+// URL generation / param encoding and may indicate a frontend bug.
+const SUPPRESS_FROM_SENTRY = new Set<string>([
+  ErrorCodes.REPORT_NOT_FOUND,
+  ErrorCodes.FIGHT_NOT_FOUND,
+  ErrorCodes.WCL_API_ERROR,
+  ErrorCodes.WCL_RATE_LIMITED,
+  ErrorCodes.UNAUTHORIZED,
+])
+
 function resolveRetryAfterHeader(
   details?: Record<string, unknown>,
 ): string | null {
@@ -175,7 +186,7 @@ export const errorHandler: ErrorHandler<{
   console.error(`[${requestId}] Error:`, err)
 
   if (err instanceof AppError) {
-    if (err.statusCode >= 500) {
+    if (!SUPPRESS_FROM_SENTRY.has(err.code)) {
       Sentry.captureException(err)
     }
 


### PR DESCRIPTION
## Summary

- Replace `statusCode >= 500` Sentry guard with an explicit `SUPPRESS_FROM_SENTRY` set
- Suppresses `REPORT_NOT_FOUND`, `FIGHT_NOT_FOUND`, `WCL_API_ERROR`, `WCL_RATE_LIMITED`, `UNAUTHORIZED` — these are expected operational noise
- Now captures `INVALID_*` (400s) — malformed params could indicate a frontend bug generating bad URLs

**Key behavior change:** `WCL_API_ERROR` was a 502 so the old `>= 500` rule was sending it to Sentry; it is now suppressed since upstream WCL instability is not actionable for us.

## Test plan

- [x] `pnpm --filter @wow-threat/api exec vitest run src/middleware/error.test.ts` — 23 tests pass
- [x] `pnpm --filter @wow-threat/api lint` — clean
- [x] `pnpm --filter @wow-threat/api typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)