### PR TITLE
feat(web): improve empty recents UX and refresh example reports

### DIFF
--- a/apps/web/src/components/example-report-list.tsx
+++ b/apps/web/src/components/example-report-list.tsx
@@ -6,7 +6,6 @@ import type { FC } from 'react'
 import { Link } from 'react-router-dom'
 
 import type { ExampleReportLink } from '../types/app'
-import { Card, CardContent } from './ui/card'
 
 export type ExampleReportListProps = {
   examples: ExampleReportLink[]
@@ -16,26 +15,26 @@ export const ExampleReportList: FC<ExampleReportListProps> = ({ examples }) => {
   const posthog = usePostHog()
 
   return (
-    <ul aria-label="Example reports" className="space-y-2">
+    <ul aria-label="Example reports" className="space-y-1">
       {examples.map((example) => (
         <li key={example.reportId}>
-          <Card className="bg-panel" size="sm">
-            <CardContent className="space-y-1">
-              <Link
-                className="font-medium underline"
-                state={{ host: example.host }}
-                to={`/report/${example.reportId}`}
-                onClick={() => {
-                  posthog?.capture('recents_example_opened', {
-                    report_id: example.reportId,
-                  })
-                }}
-              >
-                {example.label}
-              </Link>
-              <p className="text-xs text-muted">{example.host}</p>
-            </CardContent>
-          </Card>
+          <Link
+            className="group flex items-baseline gap-2 font-medium underline"
+            state={{ host: example.host }}
+            to={`/report/${example.reportId}`}
+            onClick={() => {
+              posthog?.capture('recents_example_opened', {
+                report_id: example.reportId,
+              })
+            }}
+          >
+            {example.label}
+            {example.zoneName ? (
+              <span className="text-xs font-normal text-muted-foreground no-underline group-hover:text-foreground">
+                {example.zoneName}
+              </span>
+            ) : null}
+          </Link>
         </li>
       ))}
     </ul>

--- a/apps/web/src/components/recent-reports-list.test.tsx
+++ b/apps/web/src/components/recent-reports-list.test.tsx
@@ -189,10 +189,12 @@ describe('RecentReportsList', () => {
       </MemoryRouter>,
     )
 
-    expect(screen.getByText('No recent reports yet (fresh)')).toBeVisible()
-    expect(screen.getByText('Example logs')).toBeVisible()
     expect(
-      screen.getByRole('link', { name: 'Fresh Example', exact: true }),
+      screen.getByText(
+        'Load a report to populate zone - date and time - boss count.',
+      ),
     ).toBeVisible()
+    expect(screen.getByText('Example logs')).toBeVisible()
+    expect(screen.getByRole('link', { name: /Fresh Example/ })).toBeVisible()
   })
 })

--- a/apps/web/src/components/recent-reports-list.tsx
+++ b/apps/web/src/components/recent-reports-list.tsx
@@ -74,24 +74,19 @@ export const RecentReportsList: FC<RecentReportsListProps> = ({
   const posthog = usePostHog()
   if (reports.length === 0) {
     return (
-      <Card className="bg-panel" size="sm">
-        <CardContent className="space-y-4">
-          <p className="font-medium text-muted-foreground">
-            No recent reports yet (fresh)
-          </p>
-          <p className="text-xs text-muted-foreground">
-            Load a report to populate zone - date and time - boss count.
-          </p>
-          {exampleReports && exampleReports.length > 0 ? (
-            <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Example logs
-              </p>
-              <ExampleReportList examples={exampleReports} />
-            </div>
-          ) : null}
-        </CardContent>
-      </Card>
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Load a report to populate zone - date and time - boss count.
+        </p>
+        {exampleReports && exampleReports.length > 0 ? (
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Example logs
+            </p>
+            <ExampleReportList examples={exampleReports} />
+          </div>
+        ) : null}
+      </div>
     )
   }
 

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -24,20 +24,23 @@ export const defaultHost: WarcraftLogsHost = 'fresh.warcraftlogs.com'
 export const exampleReports: ExampleReportLink[] = [
   {
     label: 'Fresh Example',
-    reportId: 'f9yPamzBxQqhGndZ',
+    reportId: 'T43YpndkCZ8zVayw',
     host: 'fresh.warcraftlogs.com',
-    href: 'https://fresh.warcraftlogs.com/reports/f9yPamzBxQqhGndZ?view=rankings&fight=26',
+    href: 'https://fresh.warcraftlogs.com/reports/T43YpndkCZ8zVayw?fight=15',
+    zoneName: "Gruul's Lair / Magtheridon",
   },
   {
     label: 'SoD Example',
-    reportId: 'DcCXarqJMBRkTPgA',
+    reportId: 'gbQwq2kP9WH6yJMd',
     host: 'sod.warcraftlogs.com',
-    href: 'https://sod.warcraftlogs.com/reports/DcCXarqJMBRkTPgA?view=rankings&boss=-2&difficulty=0&wipes=2',
+    href: 'https://sod.warcraftlogs.com/reports/gbQwq2kP9WH6yJMd?fight=17',
+    zoneName: 'Scarlet Enclave',
   },
   {
     label: 'Vanilla Era Example',
-    reportId: 'DtFAg9L2WBZabRX8',
+    reportId: 'TGw2BFt7DVWgQh81',
     host: 'vanilla.warcraftlogs.com',
-    href: 'https://vanilla.warcraftlogs.com/reports/DtFAg9L2WBZabRX8?boss=-2&wipes=2&view=rankings&difficulty=0',
+    href: 'https://vanilla.warcraftlogs.com/reports/TGw2BFt7DVWgQh81?fight=38',
+    zoneName: 'Naxxramas',
   },
 ]

--- a/apps/web/src/pages/landing-page.spec.ts
+++ b/apps/web/src/pages/landing-page.spec.ts
@@ -7,6 +7,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import {
+  e2eFreshExampleReportId,
   e2eReportId,
   e2eReportResponse,
   e2eValidFreshReportUrl,
@@ -109,7 +110,7 @@ test.describe('landing page', () => {
     await maybeCaptureScreenshot(page)
     await recentReports.exampleReportLink('Fresh Example').click()
 
-    await expectPathname(page, `/report/${e2eReportId}`)
+    await expectPathname(page, `/report/${e2eFreshExampleReportId}`)
   })
 
   test('report history can be revisited from recent reports', async ({

--- a/apps/web/src/test/helpers/e2e-threat-mocks.ts
+++ b/apps/web/src/test/helpers/e2e-threat-mocks.ts
@@ -17,6 +17,7 @@ import type {
 export const e2eReportId = 'f9yPamzBxQqhGndZ'
 export const e2eReportTitle = 'Threat Regression Raid'
 export const e2eValidFreshReportUrl = `https://fresh.warcraftlogs.com/reports/${e2eReportId}?view=rankings&fight=26`
+export const e2eFreshExampleReportId = 'T43YpndkCZ8zVayw'
 const fixateSpellId = 6795
 
 const reportActors: ReportActorSummary[] = [

--- a/apps/web/src/test/page-objects/landing-page/recent-reports-object.ts
+++ b/apps/web/src/test/page-objects/landing-page/recent-reports-object.ts
@@ -15,7 +15,9 @@ export class RecentReportsObject {
   }
 
   noRecentReportsText(): Locator {
-    return this.recentReportsSection().getByText(/No recent reports yet/i)
+    return this.recentReportsSection().getByText(
+      /Load a report to populate zone/i,
+    )
   }
 
   recentReportsList(): Locator {
@@ -48,8 +50,7 @@ export class RecentReportsObject {
 
   exampleReportLink(name: string): Locator {
     return this.exampleReportsSection().getByRole('link', {
-      name,
-      exact: true,
+      name: new RegExp(name),
     })
   }
 }

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -70,6 +70,7 @@ export interface ExampleReportLink {
   reportId: string
   host: WarcraftLogsHost
   href: string
+  zoneName?: string
 }
 
 export interface WowheadLinksConfig {


### PR DESCRIPTION
## Summary

- Remove outer `Card` wrapper from the empty-recents state — eliminates the cards-within-cards visual and makes the text more readable against the background
- Replace per-item `Card` layout in `ExampleReportList` with plain inline links (label + zone name inline)
- Show zone name instead of domain as the secondary label on each example link (e.g. "Scarlet Enclave" instead of "sod.warcraftlogs.com")
- Add optional `zoneName` field to `ExampleReportLink` type
- Replace archived/stale example report codes with top execution-ranked logs sourced from the WCL API:
  - **Fresh**: Magtheridon 0-death 25-man — "Refined" on Nightslayer (US)
  - **SoD**: Caldoran 0-death 20-man — "Praxis" on Living Flame (EU)
  - **Vanilla**: Kel'Thuzad 0-death 40-man — "Classic Forever" on Whitemane (US)

## Test plan

- [ ] Visit landing page with no recent reports — confirm empty state shows description text and example links without nested cards
- [ ] Confirm each example link shows zone name (Gruul's Lair / Magtheridon, Scarlet Enclave, Naxxramas) as secondary label
- [ ] Click each example link and confirm it loads the correct report
- [ ] Visit landing page with recent reports — confirm populated list is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)