### PR TITLE
refactor: extract aura serialization helpers and threat engine runner to shared

### DIFF
--- a/apps/api/src/middleware/error.test.ts
+++ b/apps/api/src/middleware/error.test.ts
@@ -14,12 +14,12 @@ import {
   fightNotFound,
   firestoreError,
   invalidFightId,
+  invalidGameVersion,
   invalidReportCode,
   reportNotFound,
   unauthorized,
   wclApiError,
   wclRateLimited,
-  invalidGameVersion,
 } from './error'
 
 vi.mock('@sentry/cloudflare', () => ({

--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -8,6 +8,7 @@ import {
   getSupportedGameVersions,
   resolveConfigOrNull,
 } from '@wow-threat/config'
+import { serializeInitialAurasByActor } from '@wow-threat/shared'
 import { Hono } from 'hono'
 
 import {
@@ -48,19 +49,6 @@ function parseEventsCursor(value: string | undefined): number | undefined {
   }
 
   return Number.parseInt(value, 10)
-}
-
-function serializeInitialAurasByActor(
-  initialAurasByActor: Map<number, readonly number[]>,
-): Record<string, number[]> {
-  return Object.fromEntries(
-    [...initialAurasByActor.entries()]
-      .filter(([, auraIds]) => auraIds.length > 0)
-      .map(([actorId, auraIds]) => [
-        String(actorId),
-        [...new Set(auraIds)].sort((left, right) => left - right),
-      ]),
-  )
 }
 
 function countSerializedInitialAuraIds(

--- a/apps/web/src/components/threat-chart-tooltip.tsx
+++ b/apps/web/src/components/threat-chart-tooltip.tsx
@@ -4,15 +4,15 @@
 import { HitTypeCode, ResourceTypeCode } from '@wow-threat/wcl-types'
 import { renderToString } from 'react-dom/server'
 
+import type { ThreatChartThemeColors } from '../hooks/use-threat-chart-theme-colors'
+import { resolveSpellSchoolColor } from '../lib/spell-school-colors'
+import type { TooltipPointPayload } from '../lib/threat-chart-types'
+import { resolveThreatStateStatus } from '../lib/threat-chart-visuals'
+import type { ThreatSeries } from '../types/app'
 import {
   ThreatChartTooltipContent,
   type ThreatChartTooltipContentData,
 } from './threat-chart-tooltip-content'
-import type { ThreatChartThemeColors } from '../hooks/use-threat-chart-theme-colors'
-import type { ThreatSeries } from '../types/app'
-import { resolveSpellSchoolColor } from '../lib/spell-school-colors'
-import type { TooltipPointPayload } from '../lib/threat-chart-types'
-import { resolveThreatStateStatus } from '../lib/threat-chart-visuals'
 
 export {
   bossMeleeMarkerColor,

--- a/apps/web/src/components/threat-chart.tsx
+++ b/apps/web/src/components/threat-chart.tsx
@@ -21,7 +21,6 @@ import { resolveCssColor } from '../lib/class-colors'
 import { formatTimelineTime } from '../lib/format'
 import { resolveSeriesWindowBounds } from '../lib/threat-aggregation'
 import { resolvePointSize } from '../lib/threat-chart-point-size'
-import { createThreatChartTooltipFormatter } from './threat-chart-tooltip'
 import {
   deathMarkerColor,
   playheadColor,
@@ -31,6 +30,7 @@ import { buildAuraMarkArea } from '../lib/threat-chart-visuals'
 import type { BossDamageMode, ThreatSeries } from '../types/app'
 import { ThreatChartLegend } from './threat-chart-legend'
 import { ThreatChartPlayerSearch } from './threat-chart-player-search'
+import { createThreatChartTooltipFormatter } from './threat-chart-tooltip'
 
 export type ThreatChartProps = {
   series: ThreatSeries[]

--- a/apps/web/src/hooks/use-threat-chart-series-data.ts
+++ b/apps/web/src/hooks/use-threat-chart-series-data.ts
@@ -4,14 +4,14 @@
 import { useMemo } from 'react'
 
 import {
-  shouldRenderThreatPoint,
-  sortThreatPointsForRendering,
-} from '../lib/threat-chart-event-visibility'
-import {
   bossMeleeMarkerColor,
   deathMarkerColor,
   tranquilAirTotemMarkerColor,
 } from '../components/threat-chart-tooltip'
+import {
+  shouldRenderThreatPoint,
+  sortThreatPointsForRendering,
+} from '../lib/threat-chart-event-visibility'
 import type { SeriesChartPoint } from '../lib/threat-chart-types'
 import { buildThreatStateVisualMaps } from '../lib/threat-chart-visuals'
 import type { BossDamageMode, ThreatSeries } from '../types/app'

--- a/apps/web/src/lib/client-threat-engine.ts
+++ b/apps/web/src/lib/client-threat-engine.ts
@@ -1,8 +1,7 @@
 /**
  * Client-side fight event processing using raw paginated events.
  */
-import { resolveConfigOrNull } from '@wow-threat/config'
-import { ThreatEngine, buildThreatEngineInput } from '@wow-threat/engine'
+import { ThreatEngine } from '@wow-threat/engine'
 import type {
   Report,
   ReportActor,
@@ -11,6 +10,7 @@ import type {
 } from '@wow-threat/wcl-types'
 
 import { getFightEventsPage } from '../api/reports'
+import { runThreatEngineForFight } from '../lib/threat-engine-runner'
 import {
   buildThreatWorkerJobKey,
   chunkThreatWorkerEvents,
@@ -322,50 +322,6 @@ async function runThreatEngineWorker(
   })
 }
 
-function deserializeInitialAurasByActor(
-  initialAurasByActor: Record<string, number[]> | undefined,
-): Map<number, readonly number[]> {
-  if (!initialAurasByActor) {
-    return new Map()
-  }
-
-  return Object.entries(initialAurasByActor).reduce(
-    (result, [actorId, auraIds]) => {
-      const parsedActorId = Number.parseInt(actorId, 10)
-      if (!Number.isFinite(parsedActorId)) {
-        return result
-      }
-
-      const sanitizedAuraIds = auraIds
-        .filter((auraId) => Number.isFinite(auraId))
-        .map((auraId) => Math.trunc(auraId))
-      if (sanitizedAuraIds.length === 0) {
-        return result
-      }
-
-      result.set(
-        parsedActorId,
-        [...new Set(sanitizedAuraIds)].sort((left, right) => left - right),
-      )
-      return result
-    },
-    new Map<number, readonly number[]>(),
-  )
-}
-
-function serializeInitialAurasByActor(
-  initialAurasByActor: Map<number, readonly number[]>,
-): Record<string, number[]> {
-  return Object.fromEntries(
-    [...initialAurasByActor.entries()]
-      .filter(([, auraIds]) => auraIds.length > 0)
-      .map(([actorId, auraIds]) => [
-        String(actorId),
-        [...new Set(auraIds)].sort((left, right) => left - right),
-      ]),
-  )
-}
-
 function processThreatEventsOnMainThread(params: {
   fightId: number
   inferThreatReduction: boolean
@@ -374,63 +330,11 @@ function processThreatEventsOnMainThread(params: {
   report: Report
   tankActorIds: number[]
 }): ThreatEngineWorkerProcessedPayload {
-  const {
-    fightId,
-    inferThreatReduction,
-    initialAurasByActor: serializedInitialAurasByActor,
-    rawEvents,
-    report,
-    tankActorIds,
-  } = params
-  const startedAt = performance.now()
-  const fight = report.fights.find(
-    (candidateFight) => candidateFight.id === fightId,
-  )
-  if (!fight) {
-    throw new Error(`fight ${fightId} not found in report payload`)
-  }
-
-  const config = resolveConfigOrNull({
-    report,
+  return runThreatEngineForFight({
+    engine: fallbackThreatEngine,
+    startedAt: performance.now(),
+    ...params,
   })
-  if (!config) {
-    throw new Error(
-      `no threat config for gameVersion ${report.masterData.gameVersion}`,
-    )
-  }
-
-  const initialAurasByActor = deserializeInitialAurasByActor(
-    serializedInitialAurasByActor,
-  )
-  const { actorMap, friendlyActorIds, enemies, abilitySchoolMap } =
-    buildThreatEngineInput({
-      fight,
-      actors: report.masterData.actors,
-      abilities: report.masterData.abilities,
-    })
-  const { augmentedEvents, initialAurasByActor: effectiveInitialAurasByActor } =
-    fallbackThreatEngine.processEvents({
-      rawEvents,
-      initialAurasByActor,
-      actorMap,
-      friendlyActorIds,
-      abilitySchoolMap,
-      enemies,
-      encounterId: fight.encounterID ?? null,
-      report,
-      fight,
-      inferThreatReduction,
-      tankActorIds: new Set(tankActorIds),
-      config,
-    })
-
-  return {
-    augmentedEvents,
-    initialAurasByActor: serializeInitialAurasByActor(
-      effectiveInitialAurasByActor,
-    ),
-    processDurationMs: Math.round(performance.now() - startedAt),
-  }
 }
 
 async function fetchAllRawEvents(

--- a/apps/web/src/lib/threat-engine-runner.ts
+++ b/apps/web/src/lib/threat-engine-runner.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared core threat-engine execution pipeline used by both the main-thread
+ * fallback path and the dedicated Web Worker.
+ */
+import { resolveConfigOrNull } from '@wow-threat/config'
+import { type ThreatEngine, buildThreatEngineInput } from '@wow-threat/engine'
+import {
+  deserializeInitialAurasByActor,
+  serializeInitialAurasByActor,
+} from '@wow-threat/shared'
+import type { Report, WCLEvent } from '@wow-threat/wcl-types'
+
+import type { ThreatEngineWorkerProcessedPayload } from '../workers/threat-engine-worker-types'
+
+/** Run the threat engine for a single fight and return the serialized processed payload. */
+export function runThreatEngineForFight(params: {
+  engine: ThreatEngine
+  fightId: number
+  inferThreatReduction: boolean
+  initialAurasByActor: Record<string, number[]> | undefined
+  rawEvents: WCLEvent[]
+  report: Report
+  startedAt: number
+  tankActorIds: number[]
+}): ThreatEngineWorkerProcessedPayload {
+  const {
+    engine,
+    fightId,
+    inferThreatReduction,
+    initialAurasByActor: serializedInitialAurasByActor,
+    rawEvents,
+    report,
+    startedAt,
+    tankActorIds,
+  } = params
+
+  const fight = report.fights.find(
+    (candidateFight) => candidateFight.id === fightId,
+  )
+  if (!fight) {
+    throw new Error(`fight ${fightId} not found in report payload`)
+  }
+
+  const config = resolveConfigOrNull({ report })
+  if (!config) {
+    throw new Error(
+      `no threat config for gameVersion ${report.masterData.gameVersion}`,
+    )
+  }
+
+  const initialAurasByActor = deserializeInitialAurasByActor(
+    serializedInitialAurasByActor,
+  )
+  const { actorMap, friendlyActorIds, enemies, abilitySchoolMap } =
+    buildThreatEngineInput({
+      fight,
+      actors: report.masterData.actors,
+      abilities: report.masterData.abilities,
+    })
+  const { augmentedEvents, initialAurasByActor: effectiveInitialAurasByActor } =
+    engine.processEvents({
+      rawEvents,
+      initialAurasByActor,
+      actorMap,
+      friendlyActorIds,
+      abilitySchoolMap,
+      enemies,
+      encounterId: fight.encounterID ?? null,
+      report,
+      fight,
+      inferThreatReduction,
+      tankActorIds: new Set(tankActorIds),
+      config,
+    })
+
+  return {
+    augmentedEvents,
+    initialAurasByActor: serializeInitialAurasByActor(
+      effectiveInitialAurasByActor,
+    ),
+    processDurationMs: Math.round(performance.now() - startedAt),
+  }
+}

--- a/apps/web/src/workers/threat-engine.worker.ts
+++ b/apps/web/src/workers/threat-engine.worker.ts
@@ -1,10 +1,10 @@
 /**
  * Dedicated worker for threat engine event processing.
  */
-import { resolveConfigOrNull } from '@wow-threat/config'
-import { ThreatEngine, buildThreatEngineInput } from '@wow-threat/engine'
+import { ThreatEngine } from '@wow-threat/engine'
 import type { WCLEvent } from '@wow-threat/wcl-types'
 
+import { runThreatEngineForFight } from '../lib/threat-engine-runner'
 import {
   loadThreatWorkerRawEventChunks,
   saveThreatWorkerProcessedResult,
@@ -19,50 +19,6 @@ import type {
 } from './threat-engine-worker-types'
 
 const threatEngine = new ThreatEngine()
-
-function deserializeInitialAurasByActor(
-  initialAurasByActor: Record<string, number[]> | undefined,
-): Map<number, readonly number[]> {
-  if (!initialAurasByActor) {
-    return new Map()
-  }
-
-  return Object.entries(initialAurasByActor).reduce(
-    (result, [actorId, auraIds]) => {
-      const parsedActorId = Number.parseInt(actorId, 10)
-      if (!Number.isFinite(parsedActorId)) {
-        return result
-      }
-
-      const sanitizedAuraIds = auraIds
-        .filter((auraId) => Number.isFinite(auraId))
-        .map((auraId) => Math.trunc(auraId))
-      if (sanitizedAuraIds.length === 0) {
-        return result
-      }
-
-      result.set(
-        parsedActorId,
-        [...new Set(sanitizedAuraIds)].sort((left, right) => left - right),
-      )
-      return result
-    },
-    new Map<number, readonly number[]>(),
-  )
-}
-
-function serializeInitialAurasByActor(
-  initialAurasByActor: Map<number, readonly number[]>,
-): Record<string, number[]> {
-  return Object.fromEntries(
-    [...initialAurasByActor.entries()]
-      .filter(([, auraIds]) => auraIds.length > 0)
-      .map(([actorId, auraIds]) => [
-        String(actorId),
-        [...new Set(auraIds)].sort((left, right) => left - right),
-      ]),
-  )
-}
 
 function toErrorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -130,59 +86,21 @@ function processThreatEvents(params: {
   rawEventCount: number
 } {
   const { payload, rawEvents, startedAt } = params
-  const fight = payload.report.fights.find(
-    (candidateFight) => candidateFight.id === payload.fightId,
-  )
-  if (!fight) {
-    throw new Error(`fight ${payload.fightId} not found in report payload`)
-  }
-
-  const config = resolveConfigOrNull({
+  const processedPayload = runThreatEngineForFight({
+    engine: threatEngine,
+    fightId: payload.fightId,
+    inferThreatReduction: payload.inferThreatReduction,
+    initialAurasByActor: payload.initialAurasByActor,
+    rawEvents,
     report: payload.report,
+    startedAt,
+    tankActorIds: payload.tankActorIds,
   })
-  if (!config) {
-    throw new Error(
-      `no threat config for gameVersion ${payload.report.masterData.gameVersion}`,
-    )
-  }
 
-  const initialAurasByActor = deserializeInitialAurasByActor(
-    payload.initialAurasByActor,
-  )
-  const { actorMap, friendlyActorIds, enemies, abilitySchoolMap } =
-    buildThreatEngineInput({
-      fight,
-      actors: payload.report.masterData.actors,
-      abilities: payload.report.masterData.abilities,
-    })
-
-  const { augmentedEvents, initialAurasByActor: effectiveInitialAurasByActor } =
-    threatEngine.processEvents({
-      rawEvents,
-      initialAurasByActor,
-      actorMap,
-      friendlyActorIds,
-      abilitySchoolMap,
-      enemies,
-      encounterId: fight.encounterID ?? null,
-      report: payload.report,
-      fight,
-      inferThreatReduction: payload.inferThreatReduction,
-      tankActorIds: new Set(payload.tankActorIds),
-      config,
-    })
-
-  const processDurationMs = Math.round(performance.now() - startedAt)
   return {
-    augmentedEventCount: augmentedEvents.length,
-    processDurationMs,
-    processedPayload: {
-      augmentedEvents,
-      initialAurasByActor: serializeInitialAurasByActor(
-        effectiveInitialAurasByActor,
-      ),
-      processDurationMs,
-    },
+    augmentedEventCount: processedPayload.augmentedEvents.length,
+    processDurationMs: processedPayload.processDurationMs,
+    processedPayload,
     rawEventCount: rawEvents.length,
   }
 }

--- a/packages/shared/src/aura-serialization.ts
+++ b/packages/shared/src/aura-serialization.ts
@@ -1,0 +1,49 @@
+/**
+ * Serialization helpers for initialAurasByActor, shared across API and web packages.
+ */
+
+/** Serialize a Map of actor ID → aura spell IDs to a plain JSON-compatible record. */
+export function serializeInitialAurasByActor(
+  initialAurasByActor: Map<number, readonly number[]>,
+): Record<string, number[]> {
+  return Object.fromEntries(
+    [...initialAurasByActor.entries()]
+      .filter(([, auraIds]) => auraIds.length > 0)
+      .map(([actorId, auraIds]) => [
+        String(actorId),
+        [...new Set(auraIds)].sort((left, right) => left - right),
+      ]),
+  )
+}
+
+/** Deserialize a plain record of actor ID → aura spell IDs back to a typed Map. */
+export function deserializeInitialAurasByActor(
+  initialAurasByActor: Record<string, number[]> | undefined,
+): Map<number, readonly number[]> {
+  if (!initialAurasByActor) {
+    return new Map()
+  }
+
+  return Object.entries(initialAurasByActor).reduce(
+    (result, [actorId, auraIds]) => {
+      const parsedActorId = Number.parseInt(actorId, 10)
+      if (!Number.isFinite(parsedActorId)) {
+        return result
+      }
+
+      const sanitizedAuraIds = auraIds
+        .filter((auraId) => Number.isFinite(auraId))
+        .map((auraId) => Math.trunc(auraId))
+      if (sanitizedAuraIds.length === 0) {
+        return result
+      }
+
+      result.set(
+        parsedActorId,
+        [...new Set(sanitizedAuraIds)].sort((left, right) => left - right),
+      )
+      return result
+    },
+    new Map<number, readonly number[]>(),
+  )
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './utils'
 export * from './types'
 export * from './cache-versions'
+export * from './aura-serialization'
 export * from './test/helpers/context'
 export * from './test/helpers/config'
 export * from './test/helpers/events'


### PR DESCRIPTION
## Summary

- Extract `serializeInitialAurasByActor` and `deserializeInitialAurasByActor` into `@wow-threat/shared/src/aura-serialization.ts` — these were identically duplicated across `apps/api/src/routes/events.ts`, `apps/web/src/lib/client-threat-engine.ts`, and `apps/web/src/workers/threat-engine.worker.ts`
- Create `apps/web/src/lib/threat-engine-runner.ts` with `runThreatEngineForFight`, consolidating the duplicated fight-lookup → config-resolve → engine-process pipeline that existed in both `processThreatEventsOnMainThread` (main-thread fallback) and `processThreatEvents` (web worker)
- Both `client-threat-engine.ts` and `threat-engine.worker.ts` now delegate to the shared runner; their local implementations are removed

## Test plan

- [x] `pnpm --filter @wow-threat/shared typecheck` — passes
- [x] `pnpm --filter @wow-threat/api typecheck` — passes
- [x] `pnpm --filter @wow-threat/web typecheck` — passes
- [x] `pnpm --filter @wow-threat/web test` — 398 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)