### PR TITLE
refactor(web): extract guild faction helpers shared across report-list components

### DIFF
--- a/apps/web/src/components/account-recent-reports-list.tsx
+++ b/apps/web/src/components/account-recent-reports-list.tsx
@@ -6,6 +6,10 @@ import { Link } from 'react-router-dom'
 
 import { defaultHost } from '../lib/constants'
 import { formatReportHeaderDate } from '../lib/format'
+import {
+  normalizeGuildFaction,
+  resolveTitleRowClass,
+} from '../lib/guild-faction'
 import { cn } from '../lib/utils'
 import type { RecentReportSummary } from '../types/api'
 import { Card, CardContent } from './ui/card'
@@ -14,38 +18,9 @@ export type AccountRecentReportsListProps = {
   reports: RecentReportSummary[]
 }
 
-type ReportGuildFaction = 'alliance' | 'horde' | null
-
-function normalizeGuildFaction(
-  value: string | null | undefined,
-): ReportGuildFaction {
-  if (!value) {
-    return null
-  }
-
-  const normalized = value.trim().toLowerCase()
-  if (normalized === 'alliance') {
-    return 'alliance'
-  }
-  if (normalized === 'horde') {
-    return 'horde'
-  }
-
-  return null
-}
-
-function resolveTitleRowClass(faction: ReportGuildFaction): string {
-  if (faction === 'alliance') {
-    return 'text-sky-600 dark:text-sky-400'
-  }
-  if (faction === 'horde') {
-    return 'text-red-600 dark:text-red-400'
-  }
-
-  return ''
-}
-
-function resolveSourceLabel(source: RecentReportSummary['source']): string {
+function resolveAccountSourceLabel(
+  source: RecentReportSummary['source'],
+): string {
   return source === 'guild' ? 'guild log' : 'personal log'
 }
 
@@ -76,7 +51,7 @@ export const AccountRecentReportsList: FC<AccountRecentReportsListProps> = ({
           .join(' ')
         const zoneLabel = report.zoneName ?? 'Unknown zone'
         const startLabel = formatReportHeaderDate(report.startTime)
-        const sourceLabel = resolveSourceLabel(report.source)
+        const sourceLabel = resolveAccountSourceLabel(report.source)
         const titleRowClass = resolveTitleRowClass(
           normalizeGuildFaction(report.guildFaction),
         )

--- a/apps/web/src/components/recent-reports-list.tsx
+++ b/apps/web/src/components/recent-reports-list.tsx
@@ -7,7 +7,6 @@ import { Link } from 'react-router-dom'
 
 import { formatReportHeaderDate } from '../lib/format'
 import {
-  type ReportGuildFaction,
   normalizeGuildFaction,
   resolveTitleRowClass,
 } from '../lib/guild-faction'

--- a/apps/web/src/components/recent-reports-list.tsx
+++ b/apps/web/src/components/recent-reports-list.tsx
@@ -6,6 +6,11 @@ import type { FC } from 'react'
 import { Link } from 'react-router-dom'
 
 import { formatReportHeaderDate } from '../lib/format'
+import {
+  type ReportGuildFaction,
+  normalizeGuildFaction,
+  resolveTitleRowClass,
+} from '../lib/guild-faction'
 import { cn } from '../lib/utils'
 import type {
   ExampleReportLink,
@@ -27,38 +32,7 @@ export type RecentReportsListProps = {
   ) => void
 }
 
-type ReportGuildFaction = 'alliance' | 'horde' | null
-
-function normalizeGuildFaction(
-  value: string | null | undefined,
-): ReportGuildFaction {
-  if (!value) {
-    return null
-  }
-
-  const normalized = value.trim().toLowerCase()
-  if (normalized === 'alliance') {
-    return 'alliance'
-  }
-  if (normalized === 'horde') {
-    return 'horde'
-  }
-
-  return null
-}
-
-function resolveTitleRowClass(faction: ReportGuildFaction): string {
-  if (faction === 'alliance') {
-    return 'text-sky-600 dark:text-sky-400'
-  }
-  if (faction === 'horde') {
-    return 'text-red-600 dark:text-red-400'
-  }
-
-  return ''
-}
-
-function resolveSourceLabel(report: RecentReportEntry): string {
+function resolveHostPrefixLabel(report: RecentReportEntry): string {
   const hostPrefix = report.sourceHost.split('.')[0]?.toLowerCase()
 
   return hostPrefix ?? 'unknown'
@@ -97,7 +71,7 @@ export const RecentReportsList: FC<RecentReportsListProps> = ({
         const isInaccessible = report.isAccessible === false
         const isDisabled = isArchived || isInaccessible
         const guildName = report.guildName ? `<${report.guildName}>` : null
-        const sourceLabel = resolveSourceLabel(report)
+        const sourceLabel = resolveHostPrefixLabel(report)
         const titleParts = [report.title || report.reportId, guildName]
           .filter((value): value is string => Boolean(value))
           .join(' ')

--- a/apps/web/src/components/report-summary-header.tsx
+++ b/apps/web/src/components/report-summary-header.tsx
@@ -7,14 +7,16 @@ import { Link } from 'react-router-dom'
 
 import { buildBossKillNavigationFights } from '../lib/fight-navigation'
 import { formatReportHeaderDate } from '../lib/format'
+import {
+  type ReportGuildFaction,
+  normalizeGuildFaction,
+} from '../lib/guild-faction'
 import { buildReportUrl } from '../lib/wcl-url'
 import type { ReportResponse } from '../types/api'
 import type { WarcraftLogsHost } from '../types/app'
 import { ReportStarButton } from './report-star-button'
 import { Card, CardHeader, CardTitle } from './ui/card'
 import { Skeleton } from './ui/skeleton'
-
-type ReportGuildFaction = 'alliance' | 'horde' | null
 
 export type ReportSummaryHeaderProps = {
   report: ReportResponse
@@ -25,24 +27,6 @@ export type ReportSummaryHeaderProps = {
   isStarred: boolean
   onToggleStar: () => void
   isStarToggleDisabled?: boolean
-}
-
-function normalizeGuildFaction(
-  value: string | null | undefined,
-): ReportGuildFaction {
-  if (!value) {
-    return null
-  }
-
-  const normalized = value.trim().toLowerCase()
-  if (normalized === 'alliance') {
-    return 'alliance'
-  }
-  if (normalized === 'horde') {
-    return 'horde'
-  }
-
-  return null
 }
 
 function resolveGuildTextClass(faction: ReportGuildFaction): string {

--- a/apps/web/src/components/report-url-form.tsx
+++ b/apps/web/src/components/report-url-form.tsx
@@ -6,6 +6,10 @@ import { usePostHog } from 'posthog-js/react'
 import { type FC, type ReactNode, type Ref, useState } from 'react'
 
 import { useReportAutocomplete } from '../hooks/use-report-autocomplete'
+import {
+  type ReportGuildFaction,
+  normalizeGuildFaction,
+} from '../lib/guild-faction'
 import type {
   ReportSearchMatchRange,
   ReportSearchSuggestion,
@@ -38,26 +42,6 @@ function formatSourceTag(sourceTag: string): string {
   }
 
   return 'example'
-}
-
-type ReportGuildFaction = 'alliance' | 'horde' | null
-
-function normalizeGuildFaction(
-  value: string | null | undefined,
-): ReportGuildFaction {
-  if (!value) {
-    return null
-  }
-
-  const normalized = value.trim().toLowerCase()
-  if (normalized === 'alliance') {
-    return 'alliance'
-  }
-  if (normalized === 'horde') {
-    return 'horde'
-  }
-
-  return null
 }
 
 function resolveFactionTextClass(faction: ReportGuildFaction): string {

--- a/apps/web/src/components/starred-guild-reports-list.tsx
+++ b/apps/web/src/components/starred-guild-reports-list.tsx
@@ -5,40 +5,13 @@ import type { FC } from 'react'
 import { Link } from 'react-router-dom'
 
 import { formatReportHeaderDate } from '../lib/format'
+import {
+  normalizeGuildFaction,
+  resolveTitleRowClass,
+} from '../lib/guild-faction'
 import { cn } from '../lib/utils'
 import type { StarredGuildReportEntry } from '../types/app'
 import { Card, CardContent } from './ui/card'
-
-type ReportGuildFaction = 'alliance' | 'horde' | null
-
-function normalizeGuildFaction(
-  value: string | null | undefined,
-): ReportGuildFaction {
-  if (!value) {
-    return null
-  }
-
-  const normalized = value.trim().toLowerCase()
-  if (normalized === 'alliance') {
-    return 'alliance'
-  }
-  if (normalized === 'horde') {
-    return 'horde'
-  }
-
-  return null
-}
-
-function resolveTitleRowClass(faction: ReportGuildFaction): string {
-  if (faction === 'alliance') {
-    return 'text-sky-600 dark:text-sky-400'
-  }
-  if (faction === 'horde') {
-    return 'text-red-600 dark:text-red-400'
-  }
-
-  return ''
-}
 
 export interface StarredGuildReportsListProps {
   reports: StarredGuildReportEntry[]

--- a/apps/web/src/components/starred-reports-list.tsx
+++ b/apps/web/src/components/starred-reports-list.tsx
@@ -5,48 +5,21 @@ import type { FC } from 'react'
 import { Link } from 'react-router-dom'
 
 import { formatReportHeaderDate } from '../lib/format'
+import {
+  normalizeGuildFaction,
+  resolveTitleRowClass,
+} from '../lib/guild-faction'
 import { cn } from '../lib/utils'
 import type { StarredReportEntry } from '../types/app'
 import { ReportStarButton } from './report-star-button'
 import { Card, CardContent } from './ui/card'
-
-type ReportGuildFaction = 'alliance' | 'horde' | null
 
 export interface StarredReportsListProps {
   reports: StarredReportEntry[]
   onToggleStarReport: (reportId: string) => void
 }
 
-function normalizeGuildFaction(
-  value: string | null | undefined,
-): ReportGuildFaction {
-  if (!value) {
-    return null
-  }
-
-  const normalized = value.trim().toLowerCase()
-  if (normalized === 'alliance') {
-    return 'alliance'
-  }
-  if (normalized === 'horde') {
-    return 'horde'
-  }
-
-  return null
-}
-
-function resolveTitleRowClass(faction: ReportGuildFaction): string {
-  if (faction === 'alliance') {
-    return 'text-sky-600 dark:text-sky-400'
-  }
-  if (faction === 'horde') {
-    return 'text-red-600 dark:text-red-400'
-  }
-
-  return ''
-}
-
-function resolveSourceLabel(sourceHost: string): string {
+function resolveHostPrefixLabel(sourceHost: string): string {
   return sourceHost.split('.')[0]?.toLowerCase() ?? 'unknown'
 }
 
@@ -74,7 +47,7 @@ export const StarredReportsList: FC<StarredReportsListProps> = ({
     <ul aria-label="Starred reports" className="space-y-2">
       {reports.map((report) => {
         const guildName = report.guildName ? `<${report.guildName}>` : null
-        const sourceLabel = resolveSourceLabel(report.sourceHost)
+        const sourceLabel = resolveHostPrefixLabel(report.sourceHost)
         const titleParts = [report.title || report.reportId, guildName]
           .filter((value): value is string => Boolean(value))
           .join(' ')

--- a/apps/web/src/lib/guild-faction.ts
+++ b/apps/web/src/lib/guild-faction.ts
@@ -1,0 +1,36 @@
+/**
+ * Guild faction helpers shared across report-list components.
+ */
+
+export type ReportGuildFaction = 'alliance' | 'horde' | null
+
+/** Normalize a raw faction string to a typed value, returning null for unknown values. */
+export function normalizeGuildFaction(
+  value: string | null | undefined,
+): ReportGuildFaction {
+  if (!value) {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'alliance') {
+    return 'alliance'
+  }
+  if (normalized === 'horde') {
+    return 'horde'
+  }
+
+  return null
+}
+
+/** Resolve the Tailwind class for a faction-colored title row. */
+export function resolveTitleRowClass(faction: ReportGuildFaction): string {
+  if (faction === 'alliance') {
+    return 'text-sky-600 dark:text-sky-400'
+  }
+  if (faction === 'horde') {
+    return 'text-red-600 dark:text-red-400'
+  }
+
+  return ''
+}

--- a/apps/web/src/pages/entity-reports-page.tsx
+++ b/apps/web/src/pages/entity-reports-page.tsx
@@ -13,6 +13,10 @@ import { Button } from '../components/ui/button'
 import { useEntityReports } from '../hooks/use-entity-reports'
 import { useUserSettings } from '../hooks/use-user-settings'
 import { defaultHost } from '../lib/constants'
+import {
+  type ReportGuildFaction,
+  normalizeGuildFaction,
+} from '../lib/guild-faction'
 import { buildGuildUrl } from '../lib/wcl-url'
 import type { StarredGuildReportEntry, WarcraftLogsHost } from '../types/app'
 
@@ -24,25 +28,7 @@ interface GuildReportsPageProps {
   entityId: string
 }
 
-type GuildFaction = 'alliance' | 'horde' | null
-
-function normalizeGuildFaction(value: string | null | undefined): GuildFaction {
-  if (!value) {
-    return null
-  }
-
-  const normalized = value.trim().toLowerCase()
-  if (normalized === 'alliance') {
-    return 'alliance'
-  }
-  if (normalized === 'horde') {
-    return 'horde'
-  }
-
-  return null
-}
-
-function resolveGuildTextClass(faction: GuildFaction): string {
+function resolveGuildTextClass(faction: ReportGuildFaction): string {
   if (faction === 'alliance') {
     return 'text-sky-600 dark:text-sky-400'
   }


### PR DESCRIPTION
## Summary

- Create `apps/web/src/lib/guild-faction.ts` with `ReportGuildFaction` type, `normalizeGuildFaction`, and `resolveTitleRowClass` — previously duplicated verbatim across 7 sibling files
- Remove all 7 local duplicate definitions from: `recent-reports-list.tsx`, `starred-guild-reports-list.tsx`, `account-recent-reports-list.tsx`, `starred-reports-list.tsx`, `report-url-form.tsx`, `report-summary-header.tsx`, `entity-reports-page.tsx`
- Rename the ambiguous `resolveSourceLabel` in each file to a descriptive name: `resolveHostPrefixLabel` (extracts WCL host prefix from a URL string) and `resolveAccountSourceLabel` (maps `'guild' | 'personal'` to a display label)

## Test plan

- [x] `pnpm --filter @wow-threat/web typecheck` — passes
- [x] `pnpm --filter @wow-threat/web test` — 398 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)