### PR TITLE
chore(ci): group react and react-dom dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
     ignore:
       # react-router-dom v7 causes a "Maximum update depth exceeded" infinite
       # render loop handled by React Router's ErrorBoundary. Root cause is


### PR DESCRIPTION
## Summary

- Adds a `groups` block to `.github/dependabot.yml` so that `react` and `react-dom` version bumps are always batched into a single PR, keeping them in sync.

## Test plan

- [ ] Verify next dependabot run for `react`/`react-dom` produces one combined PR instead of two separate ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)