### PR TITLE
refactor: extract duplicate engine utilities to shared packages

### DIFF
--- a/apps/web/src/lib/threat-aggregation.ts
+++ b/apps/web/src/lib/threat-aggregation.ts
@@ -1,6 +1,7 @@
 /**
  * Threat data transformation helpers for report rankings and fight chart series.
  */
+import { parseAbilitySchoolMask } from '@wow-threat/shared'
 import type {
   AugmentedEvent,
   SpellId,
@@ -507,19 +508,6 @@ function resolveStateSpellName(
   }
 
   return null
-}
-
-function parseAbilitySchoolMask(type: string | null): number {
-  if (!type) {
-    return 0
-  }
-
-  const mask = Number.parseInt(type, 10)
-  if (!Number.isFinite(mask)) {
-    return 0
-  }
-
-  return mask
 }
 
 function resolveSchoolLabelsFromMask(mask: number): string[] {

--- a/packages/engine/src/processors/party-detection.ts
+++ b/packages/engine/src/processors/party-detection.ts
@@ -9,6 +9,7 @@ import {
   createProcessorDataKey,
 } from '../event-processors'
 import type { ActorId } from '../instance-refs'
+import { resolveFriendlyActorIds } from './utils'
 
 const MAX_INFERRED_PARTY_MEMBERS = 5
 export type GroupId = number
@@ -183,17 +184,6 @@ function resolveFightFriendlyActorIds(
     ...(fight?.friendlyPlayers ?? []),
     ...(fight?.friendlyPets ?? []).map((pet) => pet.id),
   ])
-}
-
-function resolveFriendlyActorIds(
-  fightFriendlyActorIds: Set<ActorId>,
-  runtimeFriendlyActorIds: Set<ActorId> | undefined,
-): Set<ActorId> {
-  if (runtimeFriendlyActorIds && runtimeFriendlyActorIds.size > 0) {
-    return runtimeFriendlyActorIds
-  }
-
-  return fightFriendlyActorIds
 }
 
 function resolveFriendlyPlayerIds(

--- a/packages/engine/src/processors/tranquil-air-emulation.ts
+++ b/packages/engine/src/processors/tranquil-air-emulation.ts
@@ -10,6 +10,7 @@ import type {
 } from '../event-processors'
 import type { ActorId } from '../instance-refs'
 import { partyAssignmentsKey } from './party-detection'
+import { resolveFriendlyActorIds } from './utils'
 
 const TRANQUIL_AIR_TOTEM_SPELL_IDS = new Set<number>([25908])
 
@@ -52,17 +53,6 @@ function resolveFightFriendlyActorIds(
     ...(fight?.friendlyPlayers ?? []),
     ...(fight?.friendlyPets ?? []).map((pet) => pet.id),
   ])
-}
-
-function resolveFriendlyActorIds(
-  fightFriendlyActorIds: Set<ActorId>,
-  runtimeFriendlyActorIds: Set<ActorId> | undefined,
-): Set<ActorId> {
-  if (runtimeFriendlyActorIds && runtimeFriendlyActorIds.size > 0) {
-    return runtimeFriendlyActorIds
-  }
-
-  return fightFriendlyActorIds
 }
 
 function resolveOwnedPetIdsForOwners(

--- a/packages/engine/src/processors/utils.ts
+++ b/packages/engine/src/processors/utils.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared utilities for fight processor implementations.
+ */
+import type { ActorId } from '../instance-refs'
+
+/** Return the runtime friendly actor set when populated, otherwise fall back to the fight-level set. */
+export function resolveFriendlyActorIds(
+  fightFriendlyActorIds: Set<ActorId>,
+  runtimeFriendlyActorIds: Set<ActorId> | undefined,
+): Set<ActorId> {
+  if (runtimeFriendlyActorIds && runtimeFriendlyActorIds.size > 0) {
+    return runtimeFriendlyActorIds
+  }
+
+  return fightFriendlyActorIds
+}

--- a/packages/engine/src/wcl-input.ts
+++ b/packages/engine/src/wcl-input.ts
@@ -4,6 +4,7 @@
  * Utilities for converting report/fight payloads into Threat Engine input
  * structures.
  */
+import { parseAbilitySchoolMask } from '@wow-threat/shared'
 import type { Actor, Enemy, WowClass } from '@wow-threat/shared'
 import type {
   ReportAbility,
@@ -61,19 +62,6 @@ function createActorEntry(
       petOwner: actor?.type === 'Pet' ? (actor.petOwner ?? null) : undefined,
     },
   ]
-}
-
-function parseAbilitySchoolMask(type: string | null): number {
-  if (!type) {
-    return 0
-  }
-
-  const mask = Number.parseInt(type, 10)
-  if (!Number.isFinite(mask)) {
-    return 0
-  }
-
-  return mask
 }
 
 function buildAbilitySchoolMap(

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -53,6 +53,20 @@ export function debounce<T extends (...args: unknown[]) => unknown>(
   }
 }
 
+/** Parse a WCL ability school mask string to a numeric bitmask (0 if absent or non-numeric). */
+export function parseAbilitySchoolMask(type: string | null): number {
+  if (!type) {
+    return 0
+  }
+
+  const mask = Number.parseInt(type, 10)
+  if (!Number.isFinite(mask)) {
+    return 0
+  }
+
+  return mask
+}
+
 export function exists<T>(value: T | null | undefined): value is T {
   return value !== null && value !== undefined
 }


### PR DESCRIPTION
## Summary

- Extracted `resolveFriendlyActorIds` from `party-detection.ts` and `tranquil-air-emulation.ts` into a new shared file `packages/engine/src/processors/utils.ts`
- Moved `parseAbilitySchoolMask` to `@wow-threat/shared/src/utils.ts`, removing identical copies from `packages/engine/src/wcl-input.ts` and `apps/web/src/lib/threat-aggregation.ts`

## Test plan

- [ ] `pnpm --filter @wow-threat/engine typecheck` passes
- [ ] `pnpm --filter @wow-threat/web typecheck` passes
- [ ] `pnpm --filter @wow-threat/engine test` passes
- [ ] `pnpm --filter @wow-threat/web test` passes
- [ ] `pnpm --filter @wow-threat/shared test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)