### PR TITLE
refactor: make ActorContext.getActor required, remove optional chaining at call sites

### DIFF
--- a/packages/config/src/era/raids/zg.ts
+++ b/packages/config/src/era/raids/zg.ts
@@ -96,7 +96,7 @@ function forcePush(): FormulaFn {
       return undefined
     }
 
-    const boss = ctx.actors.getActor?.({
+    const boss = ctx.actors.getActor({
       id: ctx.event.sourceID,
       instanceId: ctx.event.sourceInstance,
     })

--- a/packages/engine/src/threat-engine.test.ts
+++ b/packages/engine/src/threat-engine.test.ts
@@ -621,7 +621,7 @@ describe('threat-engine', () => {
         const secondAfterProcessor: FightProcessor = {
           id: 'test/after-read-state',
           afterFightState(ctx) {
-            const sourceActor = ctx.fightState.getActor?.({
+            const sourceActor = ctx.fightState.getActor({
               id: ctx.event.sourceID,
               instanceId: ctx.event.sourceInstance,
             })
@@ -5301,7 +5301,7 @@ describe('threat-engine', () => {
           // Verify we can access fight state
           expect(ctx.actors).toBeDefined()
           // These methods should exist and be callable
-          const runtimeActor = ctx.actors.getActor?.({ id: 1 })
+          const runtimeActor = ctx.actors.getActor({ id: 1 })
           expect(runtimeActor?.name).toBe('Warrior')
           ctx.actors.getThreat(1, { id: 99 })
           ctx.actors.getPosition({ id: 1 })

--- a/packages/shared/src/test/helpers/context.ts
+++ b/packages/shared/src/test/helpers/context.ts
@@ -18,7 +18,7 @@ export interface MockEnemyRef {
 
 export interface MockActorContext {
   getPosition: (actor: MockActorRef) => { x: number; y: number } | null
-  getActor?: (actor: MockActorRef) => RuntimeActorView | null
+  getActor: (actor: MockActorRef) => RuntimeActorView | null
   getDistance: (actor1: MockActorRef, actor2: MockActorRef) => number | null
   getActorsInRange: (actor: MockActorRef, maxDistance: number) => number[]
   getThreat: (actorId: number, enemy: MockEnemyRef) => number

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -73,7 +73,7 @@ export interface ActorContext {
   // instanceId defaults to 0 when omitted.
   getPosition: (actor: ActorRef) => { x: number; y: number } | null
   /** Get a read-only runtime actor snapshot (metadata + tracked state). */
-  getActor?: (actor: ActorRef) => RuntimeActorView | null
+  getActor: (actor: ActorRef) => RuntimeActorView | null
   /** Calculate distance between two actors (null if positions unavailable) */
   getDistance: (actor1: ActorRef, actor2: ActorRef) => number | null
   /** Get actors within range of a position */


### PR DESCRIPTION
## Summary

- Removed `?` from `getActor` in `ActorContext` interface (`packages/shared/src/types.ts`) — the method was declared optional but `FightState` always provides it
- Removed `?` from `MockActorContext` interface (`packages/shared/src/test/helpers/context.ts`) to match
- Dropped unnecessary optional chaining (`?.`) at call sites: `zg.ts:99` and two locations in `threat-engine.test.ts`

## Test plan

- [ ] `pnpm --filter @wow-threat/shared typecheck` passes
- [ ] `pnpm --filter @wow-threat/engine typecheck` passes
- [ ] `pnpm --filter @wow-threat/config typecheck` passes
- [ ] All package tests pass (280 engine, 372 config, 13 shared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)