### PR TITLE
test: add missing test coverage for format helpers, instance-refs, and fight-events pipeline

### DIFF
--- a/apps/web/src/hooks/use-fight-events.test.ts
+++ b/apps/web/src/hooks/use-fight-events.test.ts
@@ -14,6 +14,10 @@ import {
   getFightEventsClientSide,
   getFightRawEventsClientSide,
 } from '../lib/client-threat-engine'
+import {
+  loadFightEventsResultCache,
+  saveFightEventsResultCache,
+} from '../lib/fight-events-result-cache'
 import { useFightEvents, useSuspenseFightEvents } from './use-fight-events'
 
 vi.mock('@tanstack/react-query', () => ({
@@ -39,6 +43,11 @@ vi.mock('../lib/client-threat-engine', () => ({
   getFightRawEventsClientSide: vi.fn(),
 }))
 
+vi.mock('../lib/fight-events-result-cache', () => ({
+  loadFightEventsResultCache: vi.fn(),
+  saveFightEventsResultCache: vi.fn(),
+}))
+
 describe('useFightEvents', () => {
   const queryClientMock = {
     cancelQueries: vi.fn(),
@@ -46,6 +55,10 @@ describe('useFightEvents', () => {
   }
 
   beforeEach(() => {
+    vi.mocked(loadFightEventsResultCache).mockReset()
+    vi.mocked(loadFightEventsResultCache).mockResolvedValue(null)
+    vi.mocked(saveFightEventsResultCache).mockReset()
+    vi.mocked(saveFightEventsResultCache).mockResolvedValue(undefined)
     vi.mocked(useQuery).mockReset()
     vi.mocked(useQuery).mockReturnValue({
       data: undefined,
@@ -271,5 +284,100 @@ describe('useFightEvents', () => {
         inferThreatReduction: false,
       }),
     )
+  })
+
+  it('returns cached result without fetching when IDB cache hits', async () => {
+    const cachedResponse = {
+      configVersion: 'test',
+      events: [{ timestamp: 1 }],
+      fightId: 12,
+      fightName: 'Patchwerk',
+      gameVersion: 2,
+      initialAurasByActor: {},
+      reportCode: 'ABC123xyz',
+    }
+    vi.mocked(loadFightEventsResultCache).mockResolvedValue(
+      cachedResponse as never,
+    )
+
+    renderHook(() => useFightEvents('ABC123xyz', 12, false, true))
+
+    const queryCall = vi.mocked(useQuery).mock.calls[0]?.[0]
+    expect(queryCall).toBeDefined()
+
+    const result = await queryCall?.queryFn({
+      signal: new AbortController().signal,
+    })
+
+    expect(result).toEqual(cachedResponse)
+    expect(getFightEventsClientSide).not.toHaveBeenCalled()
+    expect(getFightRawEventsClientSide).not.toHaveBeenCalled()
+  })
+
+  it('skips IDB cache lookup when forceFresh is enabled', async () => {
+    renderHook(() => useFightEvents('ABC123xyz', 12, false, true, true))
+
+    const queryCall = vi.mocked(useQuery).mock.calls[0]?.[0]
+    expect(queryCall).toBeDefined()
+
+    await queryCall?.queryFn({
+      signal: new AbortController().signal,
+    })
+
+    expect(loadFightEventsResultCache).not.toHaveBeenCalled()
+  })
+
+  it('saves result to IDB cache after successful fetch', async () => {
+    renderHook(() => useFightEvents('ABC123xyz', 12, false, true))
+
+    const queryCall = vi.mocked(useQuery).mock.calls[0]?.[0]
+    expect(queryCall).toBeDefined()
+
+    await queryCall?.queryFn({
+      signal: new AbortController().signal,
+    })
+
+    expect(saveFightEventsResultCache).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: expect.objectContaining({
+          reportCode: 'ABC123xyz',
+          fightId: 12,
+          inferThreatReduction: false,
+        }),
+        response: expect.objectContaining({
+          events: [],
+          fightId: 12,
+        }),
+      }),
+    )
+  })
+
+  it('skips saving to IDB cache when forceFresh is enabled', async () => {
+    renderHook(() => useFightEvents('ABC123xyz', 12, false, true, true))
+
+    const queryCall = vi.mocked(useQuery).mock.calls[0]?.[0]
+    expect(queryCall).toBeDefined()
+
+    await queryCall?.queryFn({
+      signal: new AbortController().signal,
+    })
+
+    expect(saveFightEventsResultCache).not.toHaveBeenCalled()
+  })
+
+  it('throws abort error when signal is already aborted', async () => {
+    renderHook(() => useFightEvents('ABC123xyz', 12, false, true))
+
+    const queryCall = vi.mocked(useQuery).mock.calls[0]?.[0]
+    expect(queryCall).toBeDefined()
+
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      queryCall?.queryFn({ signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(getFightEventsClientSide).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for common formatting helpers.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatClockDuration,
+  formatNumber,
+  formatReportHeaderDate,
+  formatSeconds,
+  formatTimelineTime,
+} from './format'
+
+describe('formatTimelineTime', () => {
+  it('formats zero as 0:00.000', () => {
+    expect(formatTimelineTime(0)).toBe('0:00.000')
+  })
+
+  it('formats sub-second values', () => {
+    expect(formatTimelineTime(500)).toBe('0:00.500')
+  })
+
+  it('formats exactly one second', () => {
+    expect(formatTimelineTime(1000)).toBe('0:01.000')
+  })
+
+  it('formats values with minutes', () => {
+    expect(formatTimelineTime(65500)).toBe('1:05.500')
+  })
+
+  it('clamps negative values to zero', () => {
+    expect(formatTimelineTime(-100)).toBe('0:00.000')
+  })
+
+  it('pads seconds and milliseconds', () => {
+    expect(formatTimelineTime(61009)).toBe('1:01.009')
+  })
+})
+
+describe('formatClockDuration', () => {
+  it('formats zero as 0:00', () => {
+    expect(formatClockDuration(0)).toBe('0:00')
+  })
+
+  it('formats sub-minute durations', () => {
+    expect(formatClockDuration(30000)).toBe('0:30')
+  })
+
+  it('formats exactly one minute', () => {
+    expect(formatClockDuration(60000)).toBe('1:00')
+  })
+
+  it('formats over one minute', () => {
+    expect(formatClockDuration(61000)).toBe('1:01')
+  })
+
+  it('pads seconds below 10', () => {
+    expect(formatClockDuration(65000)).toBe('1:05')
+  })
+
+  it('clamps negative values to zero', () => {
+    expect(formatClockDuration(-5000)).toBe('0:00')
+  })
+})
+
+describe('formatNumber', () => {
+  it('formats small integers', () => {
+    expect(formatNumber(42)).toBe('42')
+  })
+
+  it('adds thousands separator', () => {
+    expect(formatNumber(1234567)).toBe('1,234,567')
+  })
+
+  it('rounds decimals', () => {
+    expect(formatNumber(1.6)).toBe('2')
+  })
+})
+
+describe('formatSeconds', () => {
+  it('formats milliseconds as seconds with one decimal', () => {
+    expect(formatSeconds(1500)).toBe('1.5s')
+  })
+
+  it('formats zero', () => {
+    expect(formatSeconds(0)).toBe('0.0s')
+  })
+})
+
+describe('formatReportHeaderDate ordinal suffixes', () => {
+  function ordinalFor(day: number): string {
+    // Use a known weekday; we only care about the ordinal portion
+    const date = new Date(2026, 0, day) // January has days 1-31
+    return formatReportHeaderDate(date.getTime()).split(' ')[1]
+  }
+
+  it('uses st for 1st', () => {
+    expect(ordinalFor(1)).toBe('1st')
+  })
+
+  it('uses nd for 2nd', () => {
+    expect(ordinalFor(2)).toBe('2nd')
+  })
+
+  it('uses rd for 3rd', () => {
+    expect(ordinalFor(3)).toBe('3rd')
+  })
+
+  it('uses th for 4th', () => {
+    expect(ordinalFor(4)).toBe('4th')
+  })
+
+  it('uses th for 11th (teen exception)', () => {
+    expect(ordinalFor(11)).toBe('11th')
+  })
+
+  it('uses th for 12th (teen exception)', () => {
+    expect(ordinalFor(12)).toBe('12th')
+  })
+
+  it('uses th for 13th (teen exception)', () => {
+    expect(ordinalFor(13)).toBe('13th')
+  })
+
+  it('uses st for 21st', () => {
+    expect(ordinalFor(21)).toBe('21st')
+  })
+
+  it('uses nd for 22nd', () => {
+    expect(ordinalFor(22)).toBe('22nd')
+  })
+
+  it('uses rd for 23rd', () => {
+    expect(ordinalFor(23)).toBe('23rd')
+  })
+})

--- a/packages/engine/src/instance-refs.test.ts
+++ b/packages/engine/src/instance-refs.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for instance-aware ID key helpers.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildActorKey,
+  buildEnemyKey,
+  normalizeInstanceId,
+  parseActorKey,
+  parseEnemyKey,
+  toActorInstanceReference,
+  toEnemyInstanceReference,
+} from './instance-refs'
+
+describe('normalizeInstanceId', () => {
+  it('returns 0 when instanceId is undefined', () => {
+    expect(normalizeInstanceId(undefined)).toBe(0)
+  })
+
+  it('returns the provided instanceId when defined', () => {
+    expect(normalizeInstanceId(3)).toBe(3)
+  })
+
+  it('preserves 0 when explicitly passed', () => {
+    expect(normalizeInstanceId(0)).toBe(0)
+  })
+})
+
+describe('toActorInstanceReference', () => {
+  it('normalizes missing instanceId to 0', () => {
+    expect(toActorInstanceReference({ id: 5 })).toEqual({
+      id: 5,
+      instanceId: 0,
+    })
+  })
+
+  it('preserves explicit instanceId', () => {
+    expect(toActorInstanceReference({ id: 5, instanceId: 2 })).toEqual({
+      id: 5,
+      instanceId: 2,
+    })
+  })
+})
+
+describe('toEnemyInstanceReference', () => {
+  it('normalizes missing instanceId to 0', () => {
+    expect(toEnemyInstanceReference({ id: 10 })).toEqual({
+      id: 10,
+      instanceId: 0,
+    })
+  })
+
+  it('preserves explicit instanceId', () => {
+    expect(toEnemyInstanceReference({ id: 10, instanceId: 4 })).toEqual({
+      id: 10,
+      instanceId: 4,
+    })
+  })
+})
+
+describe('buildActorKey', () => {
+  it('builds key with default instanceId 0 when omitted', () => {
+    expect(buildActorKey({ id: 1 })).toBe('1:0')
+  })
+
+  it('builds key with explicit instanceId', () => {
+    expect(buildActorKey({ id: 1, instanceId: 2 })).toBe('1:2')
+  })
+})
+
+describe('buildEnemyKey', () => {
+  it('builds key with default instanceId 0 when omitted', () => {
+    expect(buildEnemyKey({ id: 42 })).toBe('42:0')
+  })
+
+  it('builds key with explicit instanceId', () => {
+    expect(buildEnemyKey({ id: 42, instanceId: 3 })).toBe('42:3')
+  })
+})
+
+describe('parseActorKey', () => {
+  it('parses a key back to id and instanceId', () => {
+    const key = buildActorKey({ id: 7, instanceId: 1 })
+    expect(parseActorKey(key)).toEqual({ id: 7, instanceId: 1 })
+  })
+
+  it('parses a key with instanceId 0', () => {
+    const key = buildActorKey({ id: 7 })
+    expect(parseActorKey(key)).toEqual({ id: 7, instanceId: 0 })
+  })
+})
+
+describe('parseEnemyKey', () => {
+  it('parses a key back to id and instanceId', () => {
+    const key = buildEnemyKey({ id: 99, instanceId: 5 })
+    expect(parseEnemyKey(key)).toEqual({ id: 99, instanceId: 5 })
+  })
+
+  it('parses a key with instanceId 0', () => {
+    const key = buildEnemyKey({ id: 99 })
+    expect(parseEnemyKey(key)).toEqual({ id: 99, instanceId: 0 })
+  })
+})
+
+describe('buildActorKey / parseActorKey round-trip', () => {
+  it('recovers the original reference', () => {
+    const ref = { id: 25, instanceId: 2 }
+    expect(parseActorKey(buildActorKey(ref))).toEqual(ref)
+  })
+
+  it('recovers with default instanceId', () => {
+    const ref = { id: 25 }
+    expect(parseActorKey(buildActorKey(ref))).toEqual({ id: 25, instanceId: 0 })
+  })
+})
+
+describe('buildEnemyKey / parseEnemyKey round-trip', () => {
+  it('recovers the original reference', () => {
+    const ref = { id: 100, instanceId: 7 }
+    expect(parseEnemyKey(buildEnemyKey(ref))).toEqual(ref)
+  })
+
+  it('recovers with default instanceId', () => {
+    const ref = { id: 100 }
+    expect(parseEnemyKey(buildEnemyKey(ref))).toEqual({
+      id: 100,
+      instanceId: 0,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `apps/web/src/lib/format.test.ts` — 27 tests covering `formatTimelineTime`, `formatClockDuration`, `formatNumber`, `formatSeconds`, and all ordinal suffixes (including 11th/12th/13th teen exceptions) via `formatReportHeaderDate`
- Add `packages/engine/src/instance-refs.test.ts` — 19 tests covering `normalizeInstanceId`, `toActorInstanceReference`, `toEnemyInstanceReference`, `buildActorKey`, `buildEnemyKey`, `parseActorKey`, `parseEnemyKey`, and key round-trip properties
- Extend `apps/web/src/hooks/use-fight-events.test.ts` — 5 new pipeline behavior tests: IDB cache hit short-circuits network fetch, `forceFresh` skips IDB cache read/write, result is saved to IDB after successful processing, and abort signal throws `AbortError` before fetching

## Test plan

- [x] `pnpm --filter @wow-threat/web test` — 430 tests pass
- [x] `pnpm --filter @wow-threat/engine test` — 299 tests pass
- [x] `pnpm --filter @wow-threat/web lint` + `typecheck` — clean
- [x] `pnpm --filter @wow-threat/engine lint` + `typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)